### PR TITLE
Cookbook docs

### DIFF
--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -38,6 +38,7 @@
     "@glint/environment-ember-loose": "^0.9.4",
     "@glint/environment-ember-template-imports": "^0.9.4",
     "@glint/template": "^0.9.4",
+    "@html-next/vertical-collection": "^4.0.0",
     "@nullvoxpopuli/eslint-configs": "^2.2.59",
     "@tailwindcss/typography": "^0.5.7",
     "@tsconfig/ember": "^1.0.1",

--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -114,7 +114,7 @@
     "edition": "octane"
   },
   "dependencies": {
-    "@crowdstrike/ember-oss-docs": "^1.0.17",
+    "@crowdstrike/ember-oss-docs": "^1.0.25",
     "@ember/test-waiters": "^3.0.0",
     "@embroider/router": "^1.9.0",
     "dompurify": "^2.4.0",

--- a/docs/demos/kitchen-sink/demo/demo-a.md
+++ b/docs/demos/kitchen-sink/demo/demo-a.md
@@ -1,0 +1,194 @@
+```hbs template
+<div class="flex gap-2">
+  {{#each this.table.columns as |column|}}
+    <span>
+      {{column.name}}:
+      <button {{on 'click' (fn this.hide column)}} disabled={{this.isHidden column}}>
+        Hide
+      </button>
+      <button {{on 'click' (fn this.show column)}} disabled={{this.isVisible column}}>
+        Show
+      </button>
+    </span>
+  {{/each}}
+</div>
+<div class="h-full overflow-auto" {{this.table.modifiers.container}}>
+  <table>
+    <thead>
+      <tr>
+        {{#each this.columns as |column|}}
+          <th {{this.table.modifiers.columnHeader column}} class="relative group">
+            <button {{this.resizeHandle column}} class="reset-styles absolute -left-4 cursor-col-resize focusable group-first:hidden">
+              ↔
+            </button>
+            {{#if (this.isResizing column)}}
+              <div
+                class="absolute -left-3 -top-4 bg-focus w-0.5 transition duration-150"
+                style="height: {{this.resizeHeight}}"></div>
+            {{/if}}
+
+            <span class="name">{{column.name}}</span><br>
+            <button {{on 'click' (fn this.moveLeft column)}} disabled={{this.cannotMoveLeft column}}>
+              ⇦
+            </button>
+            <button {{on 'click' (fn this.moveRight column)}} disabled={{this.cannotMoveRight column}}>
+              ⇨
+            </button>
+            <button {{on 'click' (fn this.sort column)}}>
+              {{#if (this.isAscending column)}}
+                × <span class="sr-only">remove sort</span>
+              {{else if (this.isDescending column)}}
+                ⇧ <span class="sr-only">switch to ascending sort</span>
+              {{else}}
+                ⇩ <span class="sr-only">switch to ascending sort</span>
+              {{/if}}
+            </button>
+          </th>
+        {{else}}
+          <th>
+            No columns are visible
+          </th>
+        {{/each}}
+      </tr>
+    </thead>
+    <tbody>
+      {{#each this.table.rows as |row|}}
+        <tr>
+          {{#each this.columns as |column|}}
+            <td>
+              {{column.getValueForRow row}}</td>
+          {{/each}}
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+</div>
+```
+
+```js component
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { htmlSafe } from '@ember/template';
+
+import { headlessTable } from 'ember-headless-table';
+import { meta } from 'ember-headless-table/plugins';
+import {
+  ColumnResizing,
+  isResizing, resizeHandle
+} from 'ember-headless-table/plugins/column-resizing';
+import {
+  ColumnReordering,
+  moveLeft, moveRight, cannotMoveLeft, cannotMoveRight
+} from 'ember-headless-table/plugins/column-reordering';
+import {
+  ColumnVisibility,
+  hide, show, isVisible, isHidden
+} from 'ember-headless-table/plugins/column-visibility';
+import {
+  DataSorting, sort, isAscending, isDescending
+} from 'ember-headless-table/plugins/data-sorting';
+
+import { DATA } from 'docs-app/sample-data';
+
+export default class extends Component {
+  resizeHandle = resizeHandle;
+
+  table = headlessTable(this, {
+    columns: () => [
+      { name: 'column A', key: 'A',
+        pluginOptions: [ColumnResizing.forColumn(() => ({ minWidth: 200 }))]
+      },
+      { name: 'column B', key: 'B',
+        pluginOptions: [ColumnResizing.forColumn(() => ({ minWidth: 200 }))]
+      },
+      { name: 'column C', key: 'C',
+        pluginOptions: [ColumnResizing.forColumn(() => ({ minWidth: 200 }))]
+      },
+    ],
+    data: () => this.data,
+    plugins: [
+      ColumnReordering,
+      ColumnVisibility,
+      ColumnResizing,
+      DataSorting.with(() => ({
+        sorts: this.sorts,
+        onSort: (sorts) => this.sorts = sorts,
+      })),
+    ],
+  });
+
+  @tracked sorts = [];
+
+  get columns() {
+    return meta.forTable(this.table, ColumnReordering).columns;
+  }
+
+  get data() {
+    return localSort(DATA, this.sorts);
+  }
+
+  get resizeHeight() {
+    return htmlSafe(`${this.table.scrollContainerElement.clientHeight - 32}px`)
+  }
+
+
+  /**
+   * Plugin Integration - all of this can be removed in strict mode, gjs/gts
+   *
+   * This syntax looks weird, but it's read as:
+   *   [property on this component] = [variable in scope]
+   */
+  hide = hide;
+  show = show;
+  isVisible = isVisible;
+  isHidden = isHidden;
+
+  moveLeft = moveLeft;
+  moveRight = moveRight;
+  cannotMoveRight = cannotMoveRight;
+  cannotMoveLeft = cannotMoveLeft;
+
+  sort = sort;
+  isAscending = isAscending;
+  isDescending = isDescending;
+
+  isResizing = isResizing;
+}
+
+/**
+ * Utils, not the focus of the demo.
+ * but sorting does need to be handled by you.
+ */
+
+import { compare } from '@ember/utils';
+
+function hasOwnProperty<T>(obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function getValue<T>(obj, key) {
+  if (hasOwnProperty(obj, key)) return obj[key];
+}
+
+export function localSort(data, sorts) {
+  // you'll want to sort a duplicate of the array, because Array.prototype.sort mutates.
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
+  //
+  // Beware though that if the array is reactive,
+  //   this will lose the reactivity if copying this function.
+  return [...data].sort((itemA, itemB) => {
+    for (let { direction, property } of sorts) {
+      let valueA = getValue(itemA, property);
+      let valueB = getValue(itemB, property);
+
+      let result = compare(valueA, valueB);
+
+      if (result) {
+        return direction === 'descending' ? -result : result;
+      }
+    }
+
+    return 0;
+  });
+}
+```

--- a/docs/demos/kitchen-sink/index.md
+++ b/docs/demos/kitchen-sink/index.md
@@ -4,4 +4,5 @@ This demo shows how all of the plugins integrate together.
 This could be useful for building a Table for a design system
 and maybe where further abstractions or defaults may be desired.
 
-
+Note that for smaller or more focused demos,
+please see the pages for individual plugins.

--- a/docs/demos/kitchen-sink/index.md
+++ b/docs/demos/kitchen-sink/index.md
@@ -1,0 +1,7 @@
+# Kitchen sink
+
+This demo shows how all of the plugins integrate together.
+This could be useful for building a Table for a design system
+and maybe where further abstractions or defaults may be desired.
+
+

--- a/docs/demos/lots-of-data/demo/demo-a.md
+++ b/docs/demos/lots-of-data/demo/demo-a.md
@@ -1,0 +1,116 @@
+
+```hbs template
+<div data-container class="h-full overflow-auto" {{this.table.modifiers.container}}>
+  <table>
+    <thead>
+      <tr>
+        {{#each this.table.columns as |column|}}
+          <th {{this.table.modifiers.columnHeader column}}>
+            {{column.name}}
+          </th>
+        {{/each}}
+      </tr>
+    </thead>
+    <tbody>
+      <VerticalCollection
+        @items={{this.table.rows}}
+        @containerSelector="[data-container]"
+        @key="key"
+        @estimateHeight={{37}}
+        @staticHeight={{true}}
+        @bufferSize={{5}}
+      as |row|>
+        <tr>
+          {{#each this.table.columns as |column|}}
+            <td>
+              {{column.getValueForRow row}}
+            </td>
+          {{/each}}
+        </tr>
+      </VerticalCollection>
+    </tbody>
+  </table>
+</div>
+```
+```js component
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import { headlessTable } from 'ember-headless-table';
+import { meta } from 'ember-headless-table/plugins';
+import {
+  DataSorting,
+  sortDescending, sortAscending, sortDirection
+} from 'ember-headless-table/plugins/data-sorting';
+
+import { DATA } from 'docs-app/sample-data';
+
+export default class extends Component {
+  table = headlessTable(this, {
+    columns: () => [
+      { name: 'column A', key: 'A' },
+      { name: 'column B', key: 'B' },
+      { name: 'column C', key: 'C' },
+      { name: 'column D', key: 'D' },
+    ],
+    data: () => this.data,
+    plugins: [
+      DataSorting.with(() => ({
+        sorts: this.sorts,
+        onSort: (sorts) => this.sorts = sorts,
+      })),
+    ],
+  });
+
+  @tracked sorts = [];
+
+  get data() {
+    return sort(DATA, this.sorts);
+  }
+
+  /**
+   * Plugin Integration
+   */
+  sortDirection = sortDirection;
+  sortAscending = sortAscending;
+  sortDescending = sortDescending;
+}
+
+/**
+ * Utils, not the focus of the demo.
+ * but sorting does need to be handled by you.
+ */
+
+import { compare } from '@ember/utils';
+
+function hasOwnProperty<T>(obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function getValue<T>(obj, key) {
+  if (hasOwnProperty(obj, key)) return obj[key];
+}
+
+export function sort(data, sorts) {
+  // you'll want to sort a duplicate of the array, because Array.prototype.sort mutates.
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
+  //
+  // Beware though that if the array is reactive,
+  //   this will lose the reactivity if copying this function.
+  return [...data].sort((itemA, itemB) => {
+    for (let { direction, property } of sorts) {
+      let valueA = getValue(itemA, property);
+      let valueB = getValue(itemB, property);
+
+      let result = compare(valueA, valueB);
+
+      if (result) {
+        return direction === 'descending' ? -result : result;
+      }
+    }
+
+    return 0;
+  });
+}
+```
+

--- a/docs/demos/lots-of-data/demo/demo-a.md
+++ b/docs/demos/lots-of-data/demo/demo-a.md
@@ -1,4 +1,3 @@
-
 ```hbs template
 <div data-container class="h-full overflow-auto" {{this.table.modifiers.container}}>
   <table>
@@ -13,17 +12,21 @@
     </thead>
     <tbody>
       <VerticalCollection
-        @items={{this.table.rows}}
+        @items={{ (this.table.rows.values) }}
         @containerSelector="[data-container]"
         @key="key"
         @estimateHeight={{37}}
         @staticHeight={{true}}
         @bufferSize={{5}}
       as |row|>
-        <tr>
+        <tr class="{{row.countClassName}}">
           {{#each this.table.columns as |column|}}
             <td>
-              {{column.getValueForRow row}}
+              {{#if column.Cell}}
+                <column.Cell @row={{row}} @column={{column}} />
+              {{else}}
+                {{column.getValueForRow row}}
+              {{/if}}
             </td>
           {{/each}}
         </tr>
@@ -31,86 +34,240 @@
     </tbody>
   </table>
 </div>
+<style>
+  [data-container] {
+    height: 500px;
+    overflow: scroll;
+    position: relative;
+  }
+  [data-container] thead {
+    position: sticky;
+    top: 0;
+    background: var(--basement);
+  }
+  [data-container] .label {
+    padding: 0.2rem 0.6rem 0.3rem;
+    font-size: 75%;
+    color: white;
+    border-radius: 0.25rem;
+  }
+  [data-container] th {
+    /* styling the table isn't the focus of this demo (perf is the focus) */
+    width: calc(100% / 7);
+  }
+  [data-container] th:first-child {
+    min-width: 190px;
+  }
+  [data-container] .label-success { background-color: #5cb85c; }
+  [data-container] .label-warning { background-color:#f0ad4e; }
+  [data-container] .label-danger  { background-color:#d9534f; }
+</style>
 ```
 ```js component
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
+import { tracked, cached } from '@glimmer/tracking';
+import { cell, use, resource } from 'ember-resources';
+import { map } from 'ember-resources/util/map';
 
 import { headlessTable } from 'ember-headless-table';
-import { meta } from 'ember-headless-table/plugins';
-import {
-  DataSorting,
-  sortDescending, sortAscending, sortDirection
-} from 'ember-headless-table/plugins/data-sorting';
-
-import { DATA } from 'docs-app/sample-data';
 
 export default class extends Component {
   table = headlessTable(this, {
     columns: () => [
-      { name: 'column A', key: 'A' },
-      { name: 'column B', key: 'B' },
-      { name: 'column C', key: 'C' },
-      { name: 'column D', key: 'D' },
+      { name: 'dbname', key: 'db.id' },
+      { name: 'query count', key: 'queries.length', Cell: QueryStatus },
+      { name: '', key: 'topFiveQueries.0.elapsed' },
+      { name: '', key: 'topFiveQueries.1.elapsed' },
+      { name: '', key: 'topFiveQueries.2.elapsed' },
+      { name: '', key: 'topFiveQueries.3.elapsed' },
+      { name: '', key: 'topFiveQueries.4.elapsed' },
     ],
     data: () => this.data,
-    plugins: [
-      DataSorting.with(() => ({
-        sorts: this.sorts,
-        onSort: (sorts) => this.sorts = sorts,
-      })),
-    ],
   });
 
-  @tracked sorts = [];
+  @use dbData = DBMonitor;
 
   get data() {
-    return sort(DATA, this.sorts);
+    return this.mappedData.values();
   }
 
-  /**
-   * Plugin Integration
-   */
-  sortDirection = sortDirection;
-  sortAscending = sortAscending;
-  sortDescending = sortDescending;
+  mappedData = map(this, {
+    data: () => this.dbData.databases,
+    map: (databaseData) => new Database(databaseData),
+  })
+}
+
+const DBMonitor = resource(({ on }) => {
+  let value = cell(getData(100));
+  let frame;
+  let generateData = () => {
+    // simulate receiving data as fast as possible
+    frame = requestAnimationFrame(() => {
+      value.current = getData(100);
+      generateData();
+    });
+  }
+
+  on.cleanup(() => cancelAnimationFrame(frame));
+
+  // Start the infinite requestAnimationFrame chain
+  generateData();
+
+  return () => value.current;
+});
+
+class Database {
+  constructor(db) {
+    this.db = db;
+  }
+
+  get queries() {
+    return this.db.queries;
+  }
+
+  @cached
+  get topFiveQueries() {
+    let queries = this.queries || [];
+    let topFiveQueries = queries.slice(0, 5);
+
+    while (topFiveQueries.length < 5) {
+      topFiveQueries.push({ query: '' });
+    }
+
+    return topFiveQueries.map(function(query, index) {
+      return {
+        key: String(index),
+        query: query.query,
+        elapsed: query.elapsed ? formatElapsed(query.elapsed) : '',
+        className: elapsedClass(query.elapsed)
+      };
+    });
+  }
+
+  @cached
+  get countClassName() {
+    let queries = this.queries || [];
+    let countClassName = 'label';
+
+    if (queries.length >= 20) {
+      countClassName += ' label-important';
+    } else if (queries.length >= 10) {
+      countClassName += ' label-warning';
+    } else {
+      countClassName += ' label-success';
+    }
+
+    return countClassName;
+  }
+
+
+}
+
+function elapsedClass(elapsed) {
+  if (elapsed >= 10.0) {
+    return 'elapsed warn_long';
+  } else if (elapsed >= 1.0) {
+    return 'elapsed warn';
+  } else {
+    return 'elapsed short';
+  }
+}
+
+function leftPad(str, padding, toLength) {
+  return padding.repeat((toLength - str.length) / padding.length).concat(str);
+};
+
+function formatElapsed(value) {
+  let str = parseFloat(value).toFixed(2);
+
+  if (value > 60) {
+    const minutes = Math.floor(value / 60);
+    const comps = (value % 60).toFixed(2).split('.');
+    const seconds = leftPad(comps[0], '0', 2);
+    str = `${minutes}:${seconds}.${comps[1]}`;
+  }
+
+  return str;
 }
 
 /**
- * Utils, not the focus of the demo.
- * but sorting does need to be handled by you.
+ * Temporary work-around because docfy.dev doesn't support gjs
  */
+import { setComponentTemplate } from '@ember/component';
+import templateOnly from '@ember/component/template-only';
+import { hbs } from 'ember-cli-htmlbars';
 
-import { compare } from '@ember/utils';
+const QueryStatus = templateOnly();
+setComponentTemplate(hbs`
+  <td>
+    <span class="{{@row.data.countClassName}}">
+      {{@row.data.queries.length}}
+    </span>
+  </td>
+`, QueryStatus);
 
-function hasOwnProperty<T>(obj, key) {
-  return Object.prototype.hasOwnProperty.call(obj, key);
-}
+/**
+ * dbmon code copied from
+ * https://github.com/html-next/vertical-collection/blob/master/tests/dummy/app/lib/get-data.js
+ */
+const DEFAULT_ROWS = 20;
 
-function getValue<T>(obj, key) {
-  if (hasOwnProperty(obj, key)) return obj[key];
-}
+function getData(ROWS) {
+  ROWS = ROWS || DEFAULT_ROWS;
 
-export function sort(data, sorts) {
-  // you'll want to sort a duplicate of the array, because Array.prototype.sort mutates.
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
-  //
-  // Beware though that if the array is reactive,
-  //   this will lose the reactivity if copying this function.
-  return [...data].sort((itemA, itemB) => {
-    for (let { direction, property } of sorts) {
-      let valueA = getValue(itemA, property);
-      let valueB = getValue(itemB, property);
+  // generate some dummy data
+  const data = {
+    start_at: new Date().getTime() / 1000,
+    databases: []
+  };
 
-      let result = compare(valueA, valueB);
+  for (let i = 1; i <= ROWS; i++) {
 
-      if (result) {
-        return direction === 'descending' ? -result : result;
+    data.databases.push({
+      id: `cluster${i}`,
+      queries: []
+    });
+
+    data.databases.push({
+      id: ` ↳ cluster${i}-secondary`,
+      queries: []
+    });
+
+  }
+
+  data.databases.forEach(function(info) {
+    const r = Math.floor((Math.random() * 10) + 1);
+
+    for (let i = 0; i < r; i++) {
+      const q = {
+        canvas_action: null,
+        canvas_context_id: null,
+        canvas_controller: null,
+        canvas_hostname: null,
+        canvas_job_tag: null,
+        canvas_pid: null,
+        elapsed: Math.random() * 15,
+        query: 'SELECT blah FROM something',
+        waiting: Math.random() < 0.5
+      };
+
+      if (Math.random() < 0.2) {
+        q.query = '<IDLE> in transaction';
       }
+
+      if (Math.random() < 0.1) {
+        q.query = 'vacuum';
+      }
+
+      info.queries.push(q);
     }
 
-    return 0;
+    info.queries = info.queries.sort(function(a, b) {
+      return b.elapsed - a.elapsed;
+    });
   });
+
+  return data;
 }
 ```
 

--- a/docs/demos/lots-of-data/index.md
+++ b/docs/demos/lots-of-data/index.md
@@ -1,0 +1,5 @@
+# Lots of data
+
+Using [@html-next/vertical-collection][gh-vc], we can have many many rows with very frequent updates optimally rendered.
+
+[gh-vc]: https://github.com/html-next/vertical-collection

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,7 @@ importers:
       '@glint/environment-ember-loose': ^0.9.4
       '@glint/environment-ember-template-imports': ^0.9.4
       '@glint/template': ^0.9.4
+      '@html-next/vertical-collection': ^4.0.0
       '@nullvoxpopuli/eslint-configs': ^2.2.59
       '@tailwindcss/typography': ^0.5.7
       '@tsconfig/ember': ^1.0.1
@@ -159,6 +160,7 @@ importers:
       '@glint/environment-ember-loose': 0.9.4_q3dyqagzoarn5fdnpc2fuow56q
       '@glint/environment-ember-template-imports': 0.9.4_6rdv3jsfbhdmdytwv4dlce6dfy
       '@glint/template': 0.9.4_@glimmer+component@1.1.2
+      '@html-next/vertical-collection': 4.0.0
       '@nullvoxpopuli/eslint-configs': 2.2.59_typescript@4.8.4
       '@tailwindcss/typography': 0.5.7_tailwindcss@3.1.8
       '@tsconfig/ember': 1.0.1
@@ -1954,7 +1956,7 @@ packages:
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 5.7.2
       ember-destroyable-polyfill: 2.0.3_@babel+core@7.19.3
-      ember-source: 4.7.0_@babel+core@7.19.3
+      ember-source: 4.7.0_wfdvla2jorjoj23kkavho2upde
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -2264,7 +2266,7 @@ packages:
       '@embroider/macros': 1.8.3
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 4.7.0_@babel+core@7.19.3
+      ember-source: 4.7.0_wfdvla2jorjoj23kkavho2upde
     transitivePeerDependencies:
       - supports-color
 
@@ -2622,6 +2624,22 @@ packages:
 
   /@handlebars/parser/2.0.0:
     resolution: {integrity: sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==}
+    dev: true
+
+  /@html-next/vertical-collection/4.0.0:
+    resolution: {integrity: sha512-/c4y6ASmkMwyG+rcoXH3kx50LiK2MuPX0bsktd+j9LhOD6zkJyT4wJ73m20dCEvxjgwA/nCQ8hj3lApQlHG0CQ==}
+    engines: {node: '>= 14.*'}
+    dependencies:
+      babel6-plugin-strip-class-callcheck: 6.0.0
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      broccoli-rollup: 5.0.0
+      ember-cli-babel: 7.26.11
+      ember-cli-htmlbars: 6.1.1
+      ember-cli-version-checker: 5.1.2
+      ember-raf-scheduler: 0.3.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@humanwhocodes/config-array/0.5.0:
@@ -3114,6 +3132,15 @@ packages:
       '@types/node': 18.8.2
     dev: true
 
+  /@types/broccoli-plugin/3.0.0:
+    resolution: {integrity: sha512-f+TcsARR2PovfFRKFdCX0kfH/QoM3ZVD2h1rl2mNvrKO0fq2uBNCBsTU3JanfU4COCt5cXpTfARyUsERlC8vIw==}
+    deprecated: This is a stub types definition. broccoli-plugin provides its own type definitions, so you do not need this installed.
+    dependencies:
+      broccoli-plugin: 4.0.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@types/chai-as-promised/7.1.5:
     resolution: {integrity: sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==}
     dependencies:
@@ -3207,7 +3234,7 @@ packages:
     resolution: {integrity: sha512-d2eU8O5QtqDd/ZqMV3yzIbULh8wPx6UMvxwJ0ThnNgCIFcZLO98deM5w6m5aU6K48Xu1wWzjJBa0jktGSFWXJw==}
     dependencies:
       '@types/ember': 4.0.1_@babel+core@7.19.3
-      '@types/ember__object': 4.0.4
+      '@types/ember__object': 4.0.4_@babel+core@7.19.3
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -3216,7 +3243,7 @@ packages:
     resolution: {integrity: sha512-ggF6EoKp7o0FKmZ9UKUzsLXHfcho+mKFnHQfUL1k/sUjkHxSd33fIATYuNIGZARRn2JzhYYfRqkgRIRBsoEiaQ==}
     dependencies:
       '@types/ember': 4.0.1_@babel+core@7.19.3
-      '@types/ember__object': 4.0.4
+      '@types/ember__object': 4.0.4_@babel+core@7.19.3
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -3224,7 +3251,7 @@ packages:
   /@types/ember__controller/4.0.1:
     resolution: {integrity: sha512-4hX+CjjX2KBpcOyEpcs1SSBmxYlavdAZqcyR23JUnBS+dGjlku15BQu6ZXFKIf84x7izNhC+TrYvAOeLE/Af3w==}
     dependencies:
-      '@types/ember__object': 4.0.4
+      '@types/ember__object': 4.0.4_@babel+core@7.19.3
 
   /@types/ember__controller/4.0.1_@babel+core@7.19.3:
     resolution: {integrity: sha512-4hX+CjjX2KBpcOyEpcs1SSBmxYlavdAZqcyR23JUnBS+dGjlku15BQu6ZXFKIf84x7izNhC+TrYvAOeLE/Af3w==}
@@ -4391,6 +4418,7 @@ packages:
       loader-utils: 2.0.2
       make-dir: 3.1.0
       schema-utils: 2.7.1
+    dev: true
 
   /babel-loader/8.2.5_wfdvla2jorjoj23kkavho2upde:
     resolution: {integrity: sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==}
@@ -4851,6 +4879,10 @@ packages:
       esutils: 2.0.3
       lodash: 4.17.21
       to-fast-properties: 1.0.3
+    dev: true
+
+  /babel6-plugin-strip-class-callcheck/6.0.0:
+    resolution: {integrity: sha512-biNFJ7JAK4+9BwswDGL0dmYpvXHvswOFR/iKg3Q/f+pNxPEa5bWZkLHI1fW4spPytkHGMe7f/XtYyhzml9hiWg==}
     dev: true
 
   /babylon/6.18.0:
@@ -5418,6 +5450,23 @@ packages:
       rollup: 0.57.1
       symlink-or-copy: 1.3.1
       walk-sync: 0.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /broccoli-rollup/5.0.0:
+    resolution: {integrity: sha512-QdMuXHwsdz/LOS8zu4HP91Sfi4ofimrOXoYP/lrPdRh7lJYD87Lfq4WzzUhGHsxMfzANIEvl/7qVHKD3cFJ4tA==}
+    engines: {node: '>=12.0'}
+    dependencies:
+      '@types/broccoli-plugin': 3.0.0
+      broccoli-plugin: 4.0.7
+      fs-tree-diff: 2.0.1
+      heimdalljs: 0.2.6
+      node-modules-path: 1.0.2
+      rollup: 2.79.1
+      rollup-pluginutils: 2.8.2
+      symlink-or-copy: 1.3.1
+      walk-sync: 2.2.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6474,6 +6523,7 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 3.1.1
       semver: 7.3.8
+    dev: true
 
   /css-loader/5.2.7_webpack@5.74.0:
     resolution: {integrity: sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==}
@@ -7002,6 +7052,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - webpack
+    dev: true
 
   /ember-auto-import/2.4.2_webpack@5.74.0:
     resolution: {integrity: sha512-REh+1aJWpTkvN42a/ga41OuRpUsSW7UQfPr2wPtYx56o/xoSNhVBXejy7yV9ObrkN7gogz6fs2xZwih5cOwpYg==}
@@ -7092,7 +7143,7 @@ packages:
       ember-cache-primitive-polyfill: 1.0.1_@babel+core@7.19.3
       ember-cli-babel: 7.26.11
       ember-cli-babel-plugin-helpers: 1.1.1
-      ember-source: 4.7.0_@babel+core@7.19.3
+      ember-source: 4.7.0_wfdvla2jorjoj23kkavho2upde
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -7731,6 +7782,15 @@ packages:
       - webpack
     dev: true
 
+  /ember-raf-scheduler/0.3.0:
+    resolution: {integrity: sha512-i8JWQidNCX7n5TOTIKRDR0bnsQN9aJh/GtOJKINz2Wr+I7L7sYVhli6MFqMYNGKC9j9e6iWsznfAIxddheyEow==}
+    engines: {node: 12.* || 14.* || >= 16}
+    dependencies:
+      ember-cli-babel: 7.26.11
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /ember-resolver/8.0.3_@babel+core@7.19.3:
     resolution: {integrity: sha512-fA53fxfG821BRqNiB9mQDuzZpzSRcSAYZTYBlRQOHsJwoYdjyE7idz4YcytbSsa409G5J2kP6B+PiKOBh0odlw==}
     engines: {node: '>= 10.*'}
@@ -7799,7 +7859,7 @@ packages:
       '@glimmer/component': 1.1.2_@babel+core@7.19.3
       '@glimmer/tracking': 1.1.2
       '@glint/template': 0.9.4_@glimmer+component@1.1.2
-      ember-source: 4.7.0_@babel+core@7.19.3
+      ember-source: 4.7.0_wfdvla2jorjoj23kkavho2upde
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -7895,6 +7955,7 @@ packages:
       - '@babel/core'
       - supports-color
       - webpack
+    dev: true
 
   /ember-source/4.7.0_wfdvla2jorjoj23kkavho2upde:
     resolution: {integrity: sha512-k4R5mH7LOTXXlhxpNH3bVLhqgTfLlC5uyqVMDZxMMXmttWpRq5cOh4fL+s3/gqV9YIAK8tSyfnUAjvNK+QglQQ==}
@@ -11561,6 +11622,7 @@ packages:
         optional: true
     dependencies:
       schema-utils: 4.0.0
+    dev: true
 
   /mini-css-extract-plugin/2.6.1_webpack@5.74.0:
     resolution: {integrity: sha512-wd+SD57/K6DiV7jIR34P+s3uckTRuQvx0tKPcvjFlrEylk6P4mQ2KSWk1hblj1Kxaqok7LogKOieygXqBczNlg==}
@@ -14392,6 +14454,7 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
+    dev: true
 
   /style-loader/2.0.0_webpack@5.74.0:
     resolution: {integrity: sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
   docs-app:
     specifiers:
       '@babel/core': ^7.19.3
-      '@crowdstrike/ember-oss-docs': ^1.0.17
+      '@crowdstrike/ember-oss-docs': ^1.0.25
       '@crowdstrike/ember-toucan-styles': ^1.0.5
       '@crowdstrike/tailwind-toucan-base': ^3.3.1
       '@docfy/core': ^0.5.0
@@ -131,7 +131,7 @@ importers:
       typescript: ^4.8.4
       webpack: ^5.74.0
     dependencies:
-      '@crowdstrike/ember-oss-docs': 1.0.17_j3geqmrlntvc2i6fu2a7u3cpuy
+      '@crowdstrike/ember-oss-docs': 1.0.25_ouk7khizzwo7k3l6mmywdhl5qm
       '@ember/test-waiters': 3.0.2
       '@embroider/router': 1.9.0_6nap4nrlhytgwxhnrgcj56wvwu
       dompurify: 2.4.0
@@ -1779,13 +1779,14 @@ packages:
     dev: true
     optional: true
 
-  /@crowdstrike/ember-oss-docs/1.0.17_j3geqmrlntvc2i6fu2a7u3cpuy:
-    resolution: {integrity: sha512-5y/RYCiXqVI3GcmM9EYAu8/sj+X6lgoiYGaFmPqNeyvTQli5fq4PEh3vkhpEmCQ8hnUzyXlH4Uha19yyUtgHEA==}
+  /@crowdstrike/ember-oss-docs/1.0.25_ouk7khizzwo7k3l6mmywdhl5qm:
+    resolution: {integrity: sha512-QqHDEZkh0SgWtfr0lk+aY4DRsKkGv899wEtT30mIKxLuq4FtH6D0kkex2JYpraTyqMh4Ih64cy3vbYGF2aWMfg==}
     peerDependencies:
       '@crowdstrike/tailwind-toucan-base': ^3.3.1
       '@docfy/core': ^0.5.0
       '@docfy/ember': ^0.5.0
       '@glimmer/component': ^1.1.2
+      '@glint/environment-ember-loose': ^0.9.4
       '@glint/template': '>= 0.9.0'
       '@tailwindcss/typography': ^0.5.7
       highlight.js: ^11.6.0
@@ -1797,6 +1798,7 @@ packages:
       '@docfy/ember': 0.5.0
       '@embroider/addon-shim': 1.8.3
       '@glimmer/component': 1.1.2_@babel+core@7.19.3
+      '@glint/environment-ember-loose': 0.9.4_q3dyqagzoarn5fdnpc2fuow56q
       '@glint/template': 0.9.4_@glimmer+component@1.1.2
       '@tailwindcss/typography': 0.5.7_tailwindcss@3.1.8
       dompurify: 2.4.0
@@ -1956,7 +1958,7 @@ packages:
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 5.7.2
       ember-destroyable-polyfill: 2.0.3_@babel+core@7.19.3
-      ember-source: 4.7.0_wfdvla2jorjoj23kkavho2upde
+      ember-source: 4.7.0_@babel+core@7.19.3
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -2266,7 +2268,7 @@ packages:
       '@embroider/macros': 1.8.3
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 4.7.0_wfdvla2jorjoj23kkavho2upde
+      ember-source: 4.7.0_@babel+core@7.19.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2518,7 +2520,6 @@ packages:
       silent-error: 1.1.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@glint/core/0.9.4_typescript@4.8.4:
     resolution: {integrity: sha512-7n7nUV/kbRQ6y5AhWyO2NO1J79/h3zaBn2BJ1NXaguUvQY70/YvM15CeA4JfsrFjR8Yr2Y175QfP0Ug4MSD89Q==}
@@ -2558,7 +2559,6 @@ packages:
       ember-modifier: 3.2.7_@babel+core@7.19.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@glint/environment-ember-loose/0.9.4_t5ycb63yys2yccfcq5mlxlwezm:
     resolution: {integrity: sha512-70S8BwpfoOuoGRUvmsIF1be5vmYhzVzSnXRraa0UG6ZJm4WyrP1OqJEdl5sXTsKLsF/Gp8Fb5hc3dibP4GluNw==}
@@ -3234,7 +3234,7 @@ packages:
     resolution: {integrity: sha512-d2eU8O5QtqDd/ZqMV3yzIbULh8wPx6UMvxwJ0ThnNgCIFcZLO98deM5w6m5aU6K48Xu1wWzjJBa0jktGSFWXJw==}
     dependencies:
       '@types/ember': 4.0.1_@babel+core@7.19.3
-      '@types/ember__object': 4.0.4_@babel+core@7.19.3
+      '@types/ember__object': 4.0.4
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -3243,7 +3243,7 @@ packages:
     resolution: {integrity: sha512-ggF6EoKp7o0FKmZ9UKUzsLXHfcho+mKFnHQfUL1k/sUjkHxSd33fIATYuNIGZARRn2JzhYYfRqkgRIRBsoEiaQ==}
     dependencies:
       '@types/ember': 4.0.1_@babel+core@7.19.3
-      '@types/ember__object': 4.0.4_@babel+core@7.19.3
+      '@types/ember__object': 4.0.4
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -3251,7 +3251,7 @@ packages:
   /@types/ember__controller/4.0.1:
     resolution: {integrity: sha512-4hX+CjjX2KBpcOyEpcs1SSBmxYlavdAZqcyR23JUnBS+dGjlku15BQu6ZXFKIf84x7izNhC+TrYvAOeLE/Af3w==}
     dependencies:
-      '@types/ember__object': 4.0.4_@babel+core@7.19.3
+      '@types/ember__object': 4.0.4
 
   /@types/ember__controller/4.0.1_@babel+core@7.19.3:
     resolution: {integrity: sha512-4hX+CjjX2KBpcOyEpcs1SSBmxYlavdAZqcyR23JUnBS+dGjlku15BQu6ZXFKIf84x7izNhC+TrYvAOeLE/Af3w==}
@@ -4418,7 +4418,6 @@ packages:
       loader-utils: 2.0.2
       make-dir: 3.1.0
       schema-utils: 2.7.1
-    dev: true
 
   /babel-loader/8.2.5_wfdvla2jorjoj23kkavho2upde:
     resolution: {integrity: sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==}
@@ -6523,7 +6522,6 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 3.1.1
       semver: 7.3.8
-    dev: true
 
   /css-loader/5.2.7_webpack@5.74.0:
     resolution: {integrity: sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==}
@@ -7052,7 +7050,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - webpack
-    dev: true
 
   /ember-auto-import/2.4.2_webpack@5.74.0:
     resolution: {integrity: sha512-REh+1aJWpTkvN42a/ga41OuRpUsSW7UQfPr2wPtYx56o/xoSNhVBXejy7yV9ObrkN7gogz6fs2xZwih5cOwpYg==}
@@ -7143,7 +7140,7 @@ packages:
       ember-cache-primitive-polyfill: 1.0.1_@babel+core@7.19.3
       ember-cli-babel: 7.26.11
       ember-cli-babel-plugin-helpers: 1.1.1
-      ember-source: 4.7.0_wfdvla2jorjoj23kkavho2upde
+      ember-source: 4.7.0_@babel+core@7.19.3
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -7859,7 +7856,7 @@ packages:
       '@glimmer/component': 1.1.2_@babel+core@7.19.3
       '@glimmer/tracking': 1.1.2
       '@glint/template': 0.9.4_@glimmer+component@1.1.2
-      ember-source: 4.7.0_wfdvla2jorjoj23kkavho2upde
+      ember-source: 4.7.0_@babel+core@7.19.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -7955,7 +7952,6 @@ packages:
       - '@babel/core'
       - supports-color
       - webpack
-    dev: true
 
   /ember-source/4.7.0_wfdvla2jorjoj23kkavho2upde:
     resolution: {integrity: sha512-k4R5mH7LOTXXlhxpNH3bVLhqgTfLlC5uyqVMDZxMMXmttWpRq5cOh4fL+s3/gqV9YIAK8tSyfnUAjvNK+QglQQ==}
@@ -11622,7 +11618,6 @@ packages:
         optional: true
     dependencies:
       schema-utils: 4.0.0
-    dev: true
 
   /mini-css-extract-plugin/2.6.1_webpack@5.74.0:
     resolution: {integrity: sha512-wd+SD57/K6DiV7jIR34P+s3uckTRuQvx0tKPcvjFlrEylk6P4mQ2KSWk1hblj1Kxaqok7LogKOieygXqBczNlg==}
@@ -14454,7 +14449,6 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-    dev: true
 
   /style-loader/2.0.0_webpack@5.74.0:
     resolution: {integrity: sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==}


### PR DESCRIPTION
Only two demos for now
 - dbmon
 - "kitchen sink" -- though this is a copy of the main demo for now, because this is waiting on [this PR](https://github.com/CrowdStrike/ember-headless-table/pull/4) before adding more stuff
 
 If anyone has other ideas for "how to do X", those would be a good candidate for these types of docs.
 
 Later, we'll probably want a whole separate page / nav for _most_ of these kinds of demos, as we may have a lot.
 
 Funnest demo: https://8dbbebed.ember-headless-table.pages.dev/docs/demos/lots-of-data
 
 
 After working with these demos a bit, I'm going to be spending some of my time working with Docfy to make the authoring experience a bit better:
  - actual js/ts/hbs/gjs/gts files
  - inline gjs demos (no demos folder)
  - probably other stuff