### PR TITLE
chore(docs): add custom cell demo

### DIFF
--- a/docs/demos/custom-cells/demo/demo-a.md
+++ b/docs/demos/custom-cells/demo/demo-a.md
@@ -1,0 +1,73 @@
+```hbs template
+<div class="h-full overflow-auto" {{this.table.modifiers.container}}>
+  <table>
+    <thead>
+      <tr>
+        {{#each this.table.columns as |column|}}
+          <th {{this.table.modifiers.columnHeader column}}>
+            <span class="name">{{column.name}}</span><br>
+          </th>
+        {{/each}}
+      </tr>
+    </thead>
+    <tbody>
+      {{#each this.table.rows as |row|}}
+        <tr>
+          {{#each this.table.columns as |column|}}
+            <td {{this.table.modifiers.columnHeader column}}>
+              {{#if column.Cell}}
+                <column.Cell @data={{row.data}} @column={{column}} />
+              {{else}}
+                {{column.getValueForRow row}}
+              {{/if}}
+            </td>
+          {{/each}}
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+</div>
+```
+
+```js component
+import Component from '@glimmer/component';
+
+import { headlessTable } from 'ember-headless-table';
+import { DATA } from 'docs-app/sample-data';
+
+// or import a component from elsewhere
+// See strict-mode for a more ergonomic way to define inline components
+// https://github.com/emberjs/rfcs/pull/779
+import { hbs } from 'ember-cli-htmlbars';
+import { setComponentTemplate } from '@ember/component';
+class MyCustomComponent extends Component {
+  // For demonstration only, converts a string to a color
+  get color() {
+    let key = this.args.data[this.args.column.key];
+    let color = key.split('').map(char => char.charCodeAt(0).toString(16)).join('').slice(0, 6);
+
+    return `#${color}`;
+  }
+};
+setComponentTemplate(hbs`
+  <span
+    style="box-shadow: 0 2px 6px {{this.color}}"
+    class="ml-2 p-1 rounded border border-white"
+  >
+    {{this.color}}
+  </span>
+`, MyCustomComponent);
+
+export default class extends Component {
+  table = headlessTable(this, {
+    columns: () => [
+      { name: 'Custom Cell', key: 'A', Cell: MyCustomComponent },
+      { name: 'column B', key: 'B' },
+      { name: 'column C', key: 'C' },
+      { name: 'column D', key: 'D' },
+      { name: 'column E', key: 'E' },
+    ],
+    data: () => DATA,
+  });
+}
+```

--- a/docs/demos/custom-cells/index.md
+++ b/docs/demos/custom-cells/index.md
@@ -1,0 +1,52 @@
+# Custom cells
+
+Custom components may be used for each column via the [`ColumnConfig`'s `Cell` property][docs-column-Cell].
+
+[docs-column-Cell]: /api/interfaces/index.ColumnConfig#Cell
+
+## Using strict mode
+
+In strict mode, using bespoke components has far greater ergonomics.
+
+```js
+import Component from '@glimmer/component';
+import { headlessTable } from 'ember-headless-table';
+
+const CustomBackground =
+  <template>
+    <span style="background-color: {{@row.data.backgroundColor}}">
+      Hex: #{{@row.data.backgroundColor}}
+    </span>
+  </template>;
+
+export default class Demo extends Component {
+  table = headlessTable(this, {
+    columns: () => [
+      {
+        name: 'Background color',
+        Cell: CustomBackground,
+      }
+      /* ... */
+    ],
+    /* ... */
+  });
+
+  <template>
+    {{#each this.table.rows as |row|}}
+      <tr>
+        {{#each this.table.columns as |column|}}
+          <td>
+            {{#if column.Cell}}
+              <column.Cell @row={{row}} />
+            {{else}}
+              ...
+            {{/if}}
+          </td>
+
+        {{/each}}
+      </tr>
+    {{/each}}
+  </template>
+}
+```
+


### PR DESCRIPTION
customizing cell is not only common, but there should probably be demos for each feature ember-headless-table supports (tbd/coming soon).

