### PR TITLE
Simplify working with columns

### DIFF
--- a/docs/demos/kitchen-sink/demo/demo-a.md
+++ b/docs/demos/kitchen-sink/demo/demo-a.md
@@ -77,7 +77,7 @@ import { tracked } from '@glimmer/tracking';
 import { htmlSafe } from '@ember/template';
 
 import { headlessTable } from 'ember-headless-table';
-import { meta } from 'ember-headless-table/plugins';
+import { meta, columns } from 'ember-headless-table/plugins';
 import {
   ColumnResizing,
   isResizing, resizeHandle
@@ -139,7 +139,7 @@ export default class extends Component {
   @tracked sorts = [];
 
   get columns() {
-    return meta.forTable(this.table, ColumnReordering).columns;
+    return columns.for(this.table);
   }
 
   get data() {

--- a/docs/plugins/column-reordering/demo/dema-a.md
+++ b/docs/plugins/column-reordering/demo/dema-a.md
@@ -34,12 +34,11 @@
 import Component from '@glimmer/component';
 
 import { headlessTable } from 'ember-headless-table';
-import { meta } from 'ember-headless-table/plugins';
+import { meta, columns } from 'ember-headless-table/plugins';
 import {
   ColumnReordering,
   moveLeft, moveRight
 } from 'ember-headless-table/plugins/column-reordering';
-import { ColumnVisibility } from 'ember-headless-table/plugins/column-visibility';
 
 import { DATA } from 'docs-app/sample-data';
 
@@ -54,12 +53,11 @@ export default class extends Component {
     data: () => DATA,
     plugins: [
       ColumnReordering,
-      ColumnVisibility,
     ],
   });
 
   get columns() {
-    return meta.forTable(this.table, ColumnReordering).columns;
+    return columns.for(this.table);
   }
 
   /**

--- a/docs/plugins/column-resizing/demo/demo-a.md
+++ b/docs/plugins/column-resizing/demo/demo-a.md
@@ -62,8 +62,6 @@ export default class extends Component {
     ],
     data: () => DATA,
     plugins: [
-      ColumnVisibility,
-      ColumnReordering,
       ColumnResizing,
     ],
   });

--- a/docs/plugins/column-resizing/index.md
+++ b/docs/plugins/column-resizing/index.md
@@ -6,13 +6,9 @@ API Documentation available [here][api-docs]
 
 ## Usage
 
-Because this plugin operates or visible columns,
-the `ColumnVisibility` plugin is required.
-
 ```js
 import { headlessTable } from 'ember-headless-table';
 import { ColumnResizing, resizeHandle } from 'ember-headless-table/plugins/column-resizing';
-import { ColumnVisibility } from 'ember-headless-table/plugins/column-visibility';
 
 // ...
 // in a class
@@ -20,7 +16,6 @@ import { ColumnVisibility } from 'ember-headless-table/plugins/column-visibility
     columns: () => [ /* ... */ ],
     data: () => [ /* ... */ ],
     plugins: [
-      ColumnVisibility,
       ColumnResizing,
     ],
   })
@@ -55,7 +50,6 @@ See the API Documentation [here][api-docs] for the full list of options and desc
 table = headlessTable(this, {
   columns: () => [ /* ... */ ],
   plugins: [
-    ColumnVisibility,
     ColumnResizing.with(() => ({ handlePosition: 'right' })),
   ],
 })

--- a/docs/plugins/column-visibility/demo/demo-a.md
+++ b/docs/plugins/column-visibility/demo/demo-a.md
@@ -45,7 +45,7 @@
 import Component from '@glimmer/component';
 
 import { headlessTable } from 'ember-headless-table';
-import { meta } from 'ember-headless-table/plugins';
+import { meta, columns } from 'ember-headless-table/plugins';
 import { ColumnVisibility, hide, show } from 'ember-headless-table/plugins/column-visibility';
 
 import { DATA } from 'docs-app/sample-data';
@@ -65,7 +65,7 @@ export default class extends Component {
   });
 
   get columns() {
-    return meta.forTable(this.table, ColumnVisibility).visibleColumns;
+    return columns.for(this.table);
   }
 
   /**

--- a/docs/plugins/sticky-column/demo/demo-a.md
+++ b/docs/plugins/sticky-column/demo/demo-a.md
@@ -59,7 +59,6 @@ export default class extends Component {
     plugins: [
       StickyColumns,
       ColumnResizing,
-      ColumnVisibility,
     ],
   });
 

--- a/docs/plugins/sticky-column/index.md
+++ b/docs/plugins/sticky-column/index.md
@@ -8,7 +8,6 @@ API Documentation available [here][api-docs]
 
 ```js
 import { headlessTable } from 'ember-headless-table';
-import { ColumnVisibility } from 'ember-headless-table/plugins/column-visibility';
 import { StickyColumns } from 'ember-headless-table/plugins/sticky-columns';
 import { ColumnResizing } from 'ember-headless-table/plugins/column-resizing';
 
@@ -26,12 +25,15 @@ import { ColumnResizing } from 'ember-headless-table/plugins/column-resizing';
     ],
     data: () => [ /* ... */ ],
     plugins: [
-      ColumnReordering,
-      ColumnVisibility,
+      ColumnResizing,
       StickyColumns,
     ],
   })
 ```
+
+Note that the `ColumnResizing` plugin is requried because `StickyColumns` needs a guarantee
+that a `columnWidth` implementation exists so that columns may become sticky beyond just the
+far left and far right columns.
 
 ### ColumnOptions
 

--- a/docs/plugins/sticky-column/index.md
+++ b/docs/plugins/sticky-column/index.md
@@ -31,7 +31,7 @@ import { ColumnResizing } from 'ember-headless-table/plugins/column-resizing';
   })
 ```
 
-Note that the `ColumnResizing` plugin is requried because `StickyColumns` needs a guarantee
+Note that the `ColumnResizing` plugin is required because `StickyColumns` needs a guarantee
 that a `columnWidth` implementation exists so that columns may become sticky beyond just the
 far left and far right columns.
 

--- a/docs/plugins/writing-your-own.md
+++ b/docs/plugins/writing-your-own.md
@@ -31,6 +31,7 @@ The key properties to look at are:
   - `headerCellModifier` - for each `<th>`
   - `rowModifier` - for each `<tr>`
 - `reset` -- a hook that the table will call on your plugin if you have state to revert to
+- `columns` -- for overriding / altering column order / visibility / grouping / etc
 
 With these capabilities, features for tables may be built in a way that relieves implementation complexity on the consumer, such as:
 

--- a/ember-headless-table/src/-private/interfaces/plugins.ts
+++ b/ember-headless-table/src/-private/interfaces/plugins.ts
@@ -171,6 +171,23 @@ export interface Plugin<Signature = unknown> {
    * If the plugin has state, this should be used to reset that state
    */
   reset?: () => void;
+
+  /**
+   * @public
+   * @kind Table Hook
+   *
+   * A plugin may change the columns order, visibility, etc.
+   * By implementing this getter, this plugin's
+   * `columns` property will be used by other plugins via
+   * the `columns.for(table, RequestingPlugin)` api.
+   *
+   * For the end-consumer, they may choose to do
+   * `columns.for(table)`, which will aggregate all column modifications
+   * from all plugins.
+   *
+   * As always, `table.columns` is the way to get the unmodified list of columns.
+   */
+  columns?: Column<any>[];
 }
 
 /**

--- a/ember-headless-table/src/-private/table.ts
+++ b/ember-headless-table/src/-private/table.ts
@@ -205,6 +205,8 @@ export class Table<DataType = unknown> extends Resource<Signature<DataType>> {
 
   /**
    * @private
+   *
+   * used by other private APIs
    */
   get config() {
     return this.args.named;
@@ -233,15 +235,6 @@ export class Table<DataType = unknown> extends Resource<Signature<DataType>> {
       return new Column<DataType>(this, { ...this.defaultColumnConfig, ...config });
     },
   });
-
-  /**
-   * @private
-   *
-   * TODO: what's this for?
-   */
-  get value() {
-    return this;
-  }
 
   /**
    * @private

--- a/ember-headless-table/src/plugins/-private/base.ts
+++ b/ember-headless-table/src/plugins/-private/base.ts
@@ -242,7 +242,7 @@ export const preferences = {
  * and that upstream plugin defines a `columns` property, then those columns will be returned here.
  *
  * This works recursively up the plugin tree up until a plugin has no requirements, and then
- * all colums from the table are returned.
+ * all columns from the table are returned.
  */
 function columnsFor<DataType = any>(
   table: Table<DataType>,
@@ -334,7 +334,7 @@ export const columns = {
    * for a given current or reference column, return the column that
    * is immediately next, or to the right of that column.
    *
-   * If a plugin class is provided, the hierarchy of column list modifiecations
+   * If a plugin class is provided, the hierarchy of column list modifications
    * will be respected.
    */
   next: <Data = unknown>(
@@ -364,7 +364,7 @@ export const columns = {
    * for a given current or reference column, return the column that
    * is immediately previous, or to the left of that column.
    *
-   * If a plugin class is provided, the hierarchy of column list modifiecations
+   * If a plugin class is provided, the hierarchy of column list modifications
    * will be respected.
    */
   previous: <Data = unknown>(

--- a/ember-headless-table/src/plugins/column-resizing/plugin.ts
+++ b/ember-headless-table/src/plugins/column-resizing/plugin.ts
@@ -2,7 +2,7 @@ import { cached, tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 
-import { BasePlugin, meta, options } from '../-private/base';
+import { BasePlugin, columns, meta, options } from '../-private/base';
 import { applyStyles } from '../-private/utils';
 import { getAccurateClientHeight, getAccurateClientWidth, totalGapOf } from './utils';
 
@@ -154,8 +154,7 @@ export class ColumnMeta {
   }
 
   get hasResizeHandle() {
-    let visiblility = meta.withFeature.forTable(this.column.table, 'columnOrder');
-    let previous = visiblility.previousColumn(this.column);
+    let previous = columns.previous(this.column);
 
     if (!previous) return false;
 
@@ -250,9 +249,7 @@ export class TableMeta {
   }
 
   get #availableColumns() {
-    let otherTableMeta = meta.withFeature.forTable(this.table, 'columnOrder');
-
-    return otherTableMeta.columns;
+    return columns.for(this.table, ColumnResizing);
   }
 
   get visibleColumnMetas() {
@@ -320,12 +317,11 @@ export class TableMeta {
     let position = this.options?.handlePosition ?? 'left';
 
     let growingColumn: Column | null | undefined;
-    let visiblility = meta.withFeature.forTable(this.table, 'columnOrder');
 
     if (position === 'right') {
-      growingColumn = isDraggingRight ? visiblility.nextColumn(column) : column;
+      growingColumn = isDraggingRight ? columns.next(column) : column;
     } else {
-      growingColumn = isDraggingRight ? visiblility.previousColumn(column) : column;
+      growingColumn = isDraggingRight ? columns.previous(column) : column;
     }
 
     if (!growingColumn) return;
@@ -335,9 +331,7 @@ export class TableMeta {
     assert('cannot resize a column that does not have a width', growingColumnMeta.width);
 
     let shrinkableColumns =
-      delta > 0
-        ? visiblility.columnsAfter(growingColumn)
-        : visiblility.columnsBefore(growingColumn).reverse();
+      delta > 0 ? columns.after(growingColumn) : columns.before(growingColumn).reverse();
 
     let shrinkableColumnsMetas = shrinkableColumns
       .map((column) => meta.forColumn(column, ColumnResizing))

--- a/ember-headless-table/src/plugins/column-visibility/plugin.ts
+++ b/ember-headless-table/src/plugins/column-visibility/plugin.ts
@@ -1,5 +1,4 @@
 import { cached } from '@glimmer/tracking';
-import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 
 import { BasePlugin, meta, options, preferences } from '../-private/base';
@@ -64,6 +63,10 @@ export class ColumnVisibility extends BasePlugin<Signature> implements Plugin<Si
         preferences.forColumn(column, ColumnVisibility).delete('isVisible');
       }
     }
+  }
+
+  get columns() {
+    return meta.forTable(this.table, ColumnVisibility).visibleColumns;
   }
 }
 
@@ -149,64 +152,5 @@ export class TableMeta<Data = unknown> {
     let columnMeta = meta.forColumn(column, ColumnVisibility);
 
     columnMeta.toggle();
-
-    // TODO: REMOVE
-    // TODO: remember to reset column widths in toucan-data-table
-  }
-
-  @action
-  previousColumn(referenceColumn: Column<Data>) {
-    let visible = this.visibleColumns;
-    let referenceIndex = visible.indexOf(referenceColumn);
-
-    assert(
-      `index of reference column must be >= 0. column likely not a part of the table`,
-      referenceIndex >= 0
-    );
-
-    /**
-     * There can be nothing before the first column
-     */
-    if (referenceIndex === 0) {
-      return null;
-    }
-
-    return visible[referenceIndex - 1];
-  }
-
-  @action
-  nextColumn(referenceColumn: Column<Data>) {
-    let visible = this.visibleColumns;
-    let referenceIndex = visible.indexOf(referenceColumn);
-
-    assert(
-      `index of reference column must be >= 0. column likely not a part of the table`,
-      referenceIndex >= 0
-    );
-
-    /**
-     * There can be nothing after the last column
-     */
-    if (referenceIndex > visible.length - 1) {
-      return null;
-    }
-
-    return visible[referenceIndex + 1];
-  }
-
-  @action
-  columnsAfter(referenceColumn: Column<Data>) {
-    let visible = this.visibleColumns;
-    let referenceIndex = visible.indexOf(referenceColumn);
-
-    return visible.slice(referenceIndex + 1);
-  }
-
-  @action
-  columnsBefore(referenceColumn: Column<Data>) {
-    let visible = this.visibleColumns;
-    let referenceIndex = visible.indexOf(referenceColumn);
-
-    return visible.slice(0, referenceIndex);
   }
 }

--- a/ember-headless-table/src/plugins/index.ts
+++ b/ember-headless-table/src/plugins/index.ts
@@ -1,5 +1,5 @@
 // Public API
-export { BasePlugin, meta, options, preferences } from './-private/base';
+export { BasePlugin, columns, meta, options, preferences } from './-private/base';
 export { applyStyles, removeStyles } from './-private/utils';
 
 // Public Types

--- a/ember-headless-table/src/plugins/sticky-columns/plugin.ts
+++ b/ember-headless-table/src/plugins/sticky-columns/plugin.ts
@@ -1,7 +1,7 @@
 import { cached } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
 
-import { BasePlugin, meta, options } from '../-private/base';
+import { BasePlugin, columns, meta, options } from '../-private/base';
 import { applyStyles } from '../-private/utils';
 
 import type { ColumnApi } from '[public-plugin-types]';
@@ -37,7 +37,7 @@ export class StickyColumns extends BasePlugin<Signature> {
    * Other width-management plugins can be used instead of ColumnResizing, but they must declare
    * that they manage the width of the columns.
    */
-  static requires = ['columnWidth', 'columnVisibility'];
+  static requires = ['columnWidth'];
 
   meta = {
     table: TableMeta,
@@ -98,10 +98,8 @@ export class ColumnMeta {
       return;
     }
 
-    let visiblility = meta.withFeature.forTable(this.column.table, 'columnVisibility');
-
     if (this.position === 'left') {
-      let leftColumns = visiblility.columnsBefore(this.column);
+      let leftColumns = columns.before(this.column);
       let left = leftColumns.reduce((acc, column) => {
         let columnMeta = meta.withFeature.forColumn(column, 'columnWidth');
 
@@ -116,7 +114,7 @@ export class ColumnMeta {
     }
 
     if (this.position === 'right') {
-      let rightColumns = visiblility.columnsAfter(this.column);
+      let rightColumns = columns.after(this.column);
       let right = rightColumns.reduce((acc, column) => {
         let columnMeta = meta.withFeature.forColumn(column, 'columnWidth');
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,6 +369,7 @@ importers:
       '@types/ember__engine': ^4.0.2
       '@types/ember__error': ^4.0.0
       '@types/ember__object': ^4.0.4
+      '@types/ember__owner': ^4.0.0
       '@types/ember__polyfills': ^4.0.0
       '@types/ember__routing': ^4.0.10
       '@types/ember__runloop': ^4.0.1
@@ -454,6 +455,7 @@ importers:
       '@types/ember__engine': 4.0.2_@babel+core@7.19.3
       '@types/ember__error': 4.0.0
       '@types/ember__object': 4.0.4_@babel+core@7.19.3
+      '@types/ember__owner': 4.0.0
       '@types/ember__polyfills': 4.0.0
       '@types/ember__routing': 4.0.11_@babel+core@7.19.3
       '@types/ember__runloop': 4.0.1_@babel+core@7.19.3
@@ -2308,7 +2310,7 @@ packages:
       '@babel/core': 7.19.6
       '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.19.6
       '@babel/preset-env': 7.19.3_@babel+core@7.19.6
-      '@babel/traverse': 7.19.3
+      '@babel/traverse': 7.19.4
       '@embroider/core': 1.9.0
       '@embroider/macros': 1.9.0
       '@embroider/shared-internals': 1.8.3
@@ -2498,7 +2500,7 @@ packages:
       '@embroider/macros': 1.8.3
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 4.7.0_6zc4kxld457avlfyhj3lzsljlm
+      ember-source: 4.7.0_@babel+core@7.19.3
     transitivePeerDependencies:
       - supports-color
 
@@ -3438,6 +3440,11 @@ packages:
       - supports-color
     dev: true
 
+  /@types/ember-resolver/5.0.11:
+    resolution: {integrity: sha512-2BL9d8kBdNUO9Je6KBF7Q34BSwbQG6vzCzTeSopt8FAmLDfaDU9xDDdyZobpfy9GR36mCSeG9b9wr4bgYh/MYw==}
+    dependencies:
+      '@types/ember__object': 4.0.4
+
   /@types/ember-resolver/5.0.11_@babel+core@7.19.3:
     resolution: {integrity: sha512-2BL9d8kBdNUO9Je6KBF7Q34BSwbQG6vzCzTeSopt8FAmLDfaDU9xDDdyZobpfy9GR36mCSeG9b9wr4bgYh/MYw==}
     dependencies:
@@ -3601,7 +3608,7 @@ packages:
   /@types/ember__debug/4.0.1_@babel+core@7.19.6:
     resolution: {integrity: sha512-qrKk6Ujh6oev7TSB0eB7AEmQWKCt5t84k/K3hDvJXUiLU3YueN0kyt7aPoIAkVjC111A9FqDugl9n60+N5yeEw==}
     dependencies:
-      '@types/ember-resolver': 5.0.11_@babel+core@7.19.6
+      '@types/ember-resolver': 5.0.11
       '@types/ember__object': 4.0.4_@babel+core@7.19.6
     transitivePeerDependencies:
       - '@babel/core'
@@ -3624,7 +3631,7 @@ packages:
   /@types/ember__engine/4.0.2_@babel+core@7.19.6:
     resolution: {integrity: sha512-x9c8LtRpYwQnyUiUbGpF2+zrZiA0G3e0lPsprghllWEabnIyvN+GMdtnvt4DmpGQVeUz6JKVdoPAmENBUTTcyg==}
     dependencies:
-      '@types/ember-resolver': 5.0.11_@babel+core@7.19.6
+      '@types/ember-resolver': 5.0.11
       '@types/ember__object': 4.0.4_@babel+core@7.19.6
       '@types/ember__owner': 4.0.0
     transitivePeerDependencies:
@@ -3843,7 +3850,7 @@ packages:
   /@types/glob/8.0.0:
     resolution: {integrity: sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==}
     dependencies:
-      '@types/minimatch': 3.0.5
+      '@types/minimatch': 5.1.2
       '@types/node': 18.8.2
 
   /@types/htmlbars-inline-precompile/3.0.0:
@@ -3876,7 +3883,6 @@ packages:
 
   /@types/minimatch/5.1.2:
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
-    dev: true
 
   /@types/minimist/1.2.2:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
@@ -4535,7 +4541,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.3
+      es-abstract: 1.20.4
       get-intrinsic: 1.1.3
       is-string: 1.0.7
     dev: true
@@ -4566,7 +4572,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.3
+      es-abstract: 1.20.4
       es-shim-unscopables: 1.0.0
     dev: true
 
@@ -6032,7 +6038,7 @@ packages:
     resolution: {integrity: sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001416
+      caniuse-lite: 1.0.30001420
       electron-to-chromium: 1.4.273
     dev: true
 
@@ -6165,7 +6171,7 @@ packages:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
     dependencies:
       browserslist: 4.21.4
-      caniuse-lite: 1.0.30001416
+      caniuse-lite: 1.0.30001420
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
     dev: true
@@ -7437,7 +7443,7 @@ packages:
       semver: 6.3.0
 
   /ee-first/1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
     dev: true
 
   /electron-to-chromium/1.4.273:
@@ -8898,35 +8904,6 @@ packages:
       string-template: 0.2.1
     dev: true
 
-  /es-abstract/1.20.3:
-    resolution: {integrity: sha512-AyrnaKVpMzljIdwjzrj+LxGmj8ik2LckwXacHqrJJ/jxz6dDDBcZ7I7nlHM0FvEW8MfbWJwOd+yT2XzYW49Frw==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      es-to-primitive: 1.2.1
-      function-bind: 1.1.1
-      function.prototype.name: 1.1.5
-      get-intrinsic: 1.1.3
-      get-symbol-description: 1.0.0
-      has: 1.0.3
-      has-property-descriptors: 1.0.0
-      has-symbols: 1.0.3
-      internal-slot: 1.0.3
-      is-callable: 1.2.7
-      is-negative-zero: 2.0.2
-      is-regex: 1.1.4
-      is-shared-array-buffer: 1.0.2
-      is-string: 1.0.7
-      is-weakref: 1.0.2
-      object-inspect: 1.12.2
-      object-keys: 1.1.1
-      object.assign: 4.1.4
-      regexp.prototype.flags: 1.4.3
-      safe-regex-test: 1.0.0
-      string.prototype.trimend: 1.0.5
-      string.prototype.trimstart: 1.0.5
-      unbox-primitive: 1.0.2
-
   /es-abstract/1.20.4:
     resolution: {integrity: sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==}
     engines: {node: '>= 0.4'}
@@ -9136,7 +9113,7 @@ packages:
       eslint-import-resolver-node: 0.3.6
       eslint-module-utils: 2.7.4_f5mbxhdngza3k4m45us5fj2pj4
       has: 1.0.3
-      is-core-module: 2.10.0
+      is-core-module: 2.11.0
       is-glob: 4.0.3
       minimatch: 3.1.2
       object.values: 1.1.5
@@ -10049,7 +10026,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.3
+      es-abstract: 1.20.4
       functions-have-names: 1.2.3
 
   /functional-red-black-tree/1.0.1:
@@ -11133,7 +11110,7 @@ packages:
     dependencies:
       available-typed-arrays: 1.0.5
       call-bind: 1.0.2
-      es-abstract: 1.20.3
+      es-abstract: 1.20.4
       for-each: 0.3.3
       has-tostringtag: 1.0.0
     dev: true
@@ -12368,7 +12345,7 @@ packages:
     dev: true
 
   /mute-stream/0.0.7:
-    resolution: {integrity: sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==}
+    resolution: {integrity: sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=}
     dev: true
 
   /mute-stream/0.0.8:
@@ -12716,7 +12693,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.3
+      es-abstract: 1.20.4
     dev: true
 
   /on-finished/2.3.0:
@@ -14988,14 +14965,14 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.3
+      es-abstract: 1.20.4
 
   /string.prototype.trimstart/1.0.5:
     resolution: {integrity: sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==}
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.4
-      es-abstract: 1.20.3
+      es-abstract: 1.20.4
 
   /string_decoder/0.10.31:
     resolution: {integrity: sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==}
@@ -16397,7 +16374,7 @@ packages:
     dependencies:
       available-typed-arrays: 1.0.5
       call-bind: 1.0.2
-      es-abstract: 1.20.3
+      es-abstract: 1.20.4
       for-each: 0.3.3
       has-tostringtag: 1.0.0
       is-typed-array: 1.1.9

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -62,6 +62,7 @@
     "@types/ember__engine": "^4.0.2",
     "@types/ember__error": "^4.0.0",
     "@types/ember__object": "^4.0.4",
+    "@types/ember__owner": "^4.0.0",
     "@types/ember__polyfills": "^4.0.0",
     "@types/ember__routing": "^4.0.10",
     "@types/ember__runloop": "^4.0.1",

--- a/test-app/tests/plugins/column-resizing/rendering-test.gts
+++ b/test-app/tests/plugins/column-resizing/rendering-test.gts
@@ -272,7 +272,7 @@ module('Plugins | resizing', function (hooks) {
       table = headlessTable(this, {
         columns: () => this.columns,
         data: () => [] as unknown[],
-        plugins: [ColumnResizing, ColumnReordering, ColumnVisibility],
+        plugins: [ColumnResizing],
       });
     }
 

--- a/test-app/tests/plugins/column-visibility/rendering-test.gts
+++ b/test-app/tests/plugins/column-visibility/rendering-test.gts
@@ -8,8 +8,8 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 
 import { headlessTable } from 'ember-headless-table';
-import { meta } from 'ember-headless-table/plugins';
-import { ColumnVisibility } from 'ember-headless-table/plugins/column-visibility';
+import { meta, columns } from 'ember-headless-table/plugins';
+import { ColumnVisibility, hide, show } from 'ember-headless-table/plugins/column-visibility';
 
 import { DATA } from 'test-app/data';
 import type { ColumnConfig, Column } from 'ember-headless-table';
@@ -40,23 +40,6 @@ module('Plugins | columnVisibility', function (hooks) {
       return this.args.ctx.table;
     }
 
-    get columns() {
-      let tableMeta = meta.forTable(this.table, ColumnVisibility)
-      /**
-       * TODO: this cast is a dirty one, and should be removed.
-       *       inference "should" be able to work here.
-       */
-      return tableMeta.visibleColumns as Column<typeof DATA[number]>[];
-    }
-
-    hide = (column: Column) => {
-      return meta.forColumn(column, ColumnVisibility).hide();
-    };
-
-    show = (column: Column) => {
-      return meta.forColumn(column, ColumnVisibility).show();
-    };
-
     <template>
       <style>
         [data-scroll-container] {
@@ -72,10 +55,10 @@ module('Plugins | columnVisibility', function (hooks) {
       <div>
         {{#each this.table.columns as |column|}}
           {{column.name}}:
-          <button class="hide {{column.key}}" {{on 'click' (fn this.hide column)}}>
+          <button class="hide {{column.key}}" {{on 'click' (fn hide column)}}>
             Hide
           </button>
-          <button class="show {{column.key}}" {{on 'click' (fn this.show column)}}>
+          <button class="show {{column.key}}" {{on 'click' (fn show column)}}>
             Show
           </button>
           <br>
@@ -85,7 +68,7 @@ module('Plugins | columnVisibility', function (hooks) {
         <table>
           <thead>
             <tr>
-              {{#each this.columns as |column|}}
+              {{#each (columns.for this.table) as |column|}}
                 <th class="{{column.key}}" {{this.table.modifiers.columnHeader column}}>
                   {{column.name}}
                 </th>
@@ -99,7 +82,7 @@ module('Plugins | columnVisibility', function (hooks) {
           <tbody>
             {{#each this.table.rows as |row|}}
               <tr>
-                {{#each this.columns as |column|}}
+                {{#each (columns.for this.table) as |column|}}
                   <td>{{column.getValueForRow row}}</td>
                 {{/each}}
               </tr>

--- a/test-app/tests/plugins/consumption-test.ts
+++ b/test-app/tests/plugins/consumption-test.ts
@@ -3,10 +3,9 @@ import { setupTest } from 'ember-qunit';
 
 import { headlessTable } from 'ember-headless-table';
 import { options } from 'ember-headless-table/plugins';
-import { ColumnReordering } from 'ember-headless-table/plugins/column-reordering';
 import { ColumnResizing } from 'ember-headless-table/plugins/column-resizing';
-import { ColumnVisibility } from 'ember-headless-table/plugins/column-visibility';
 import { DataSorting } from 'ember-headless-table/plugins/data-sorting';
+import { StickyColumns } from 'ember-headless-table/plugins/sticky-columns';
 
 import type { Sort } from 'ember-headless-table/plugins/data-sorting';
 
@@ -103,12 +102,12 @@ module('Plugins | consumption', function (hooks) {
       let table = headlessTable(this, {
         columns: () => [],
         data: () => [],
-        plugins: [ColumnReordering, ColumnVisibility],
+        plugins: [ColumnResizing, StickyColumns],
       });
 
       assert.ok(
-        table.pluginOf(ColumnReordering) instanceof ColumnReordering,
-        'DataSorting plugin successfully instantiated'
+        table.pluginOf(ColumnResizing) instanceof ColumnResizing,
+        'ColumnResizing plugin successfully instantiated'
       );
     });
 
@@ -116,12 +115,12 @@ module('Plugins | consumption', function (hooks) {
       let table = headlessTable(this, {
         columns: () => [],
         data: () => [],
-        plugins: [ColumnReordering],
+        plugins: [StickyColumns],
       });
 
       assert.throws(() => {
-        table.pluginOf(ColumnReordering);
-      }, 'Configuration is missing requirement: columnVisibility, And is requested by ColumnReordering. Please add a plugin with the columnVisibility feature');
+        table.pluginOf(StickyColumns);
+      }, 'Configuration is missing requirement: columnWidth, And is requested by StickyColumns. Please add a plugin with the columnWidth feature');
     });
   });
 });

--- a/test-app/tests/plugins/queries/columns-test.ts
+++ b/test-app/tests/plugins/queries/columns-test.ts
@@ -263,6 +263,10 @@ module('Plugins | Queries | columns', function (hooks) {
   module('columns.next', function (hooks) {
     let table: Table;
 
+    /**
+     * In the OnePlugin scenario,
+     * D is hidden by default, otherwise everything is visible
+     */
     hooks.beforeEach(function () {
       let context = create(OnePlugin, this.owner);
 
@@ -313,6 +317,10 @@ module('Plugins | Queries | columns', function (hooks) {
   module('columns.previous', function (hooks) {
     let table: Table;
 
+    /**
+     * In the OnePlugin scenario,
+     * D is hidden by default, otherwise everything is visible
+     */
     hooks.beforeEach(function () {
       let context = create(OnePlugin, this.owner);
 
@@ -363,6 +371,10 @@ module('Plugins | Queries | columns', function (hooks) {
   module('columns.before', function (hooks) {
     let table: Table;
 
+    /**
+     * In the OnePlugin scenario,
+     * D is hidden by default, otherwise everything is visible
+     */
     hooks.beforeEach(function () {
       let context = create(OnePlugin, this.owner);
 
@@ -414,6 +426,10 @@ module('Plugins | Queries | columns', function (hooks) {
   module('columns.after', function (hooks) {
     let table: Table;
 
+    /**
+     * In the OnePlugin scenario,
+     * D is hidden by default, otherwise everything is visible
+     */
     hooks.beforeEach(function () {
       let context = create(OnePlugin, this.owner);
 

--- a/test-app/tests/plugins/queries/columns-test.ts
+++ b/test-app/tests/plugins/queries/columns-test.ts
@@ -1,0 +1,464 @@
+import { setOwner } from '@ember/application';
+import { assert as debugAssert } from '@ember/debug';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+import { type ColumnConfig, type Table, headlessTable } from 'ember-headless-table';
+import { columns, meta } from 'ember-headless-table/plugins';
+import { ColumnReordering } from 'ember-headless-table/plugins/column-reordering';
+import { ColumnResizing } from 'ember-headless-table/plugins/column-resizing';
+import { ColumnVisibility } from 'ember-headless-table/plugins/column-visibility';
+import { DataSorting } from 'ember-headless-table/plugins/data-sorting';
+import { StickyColumns } from 'ember-headless-table/plugins/sticky-columns';
+import { DATA } from 'test-app/data';
+
+import type Owner from '@ember/owner';
+
+interface Constructable<T> {
+  new (...args: unknown[]): T;
+}
+
+/**
+ * NOTE: the bulk of the column functionality is implemented by columns.for
+ *
+ * columns.for should be tested heavily, as it returns the columns that everything else uses.
+ * everything else (next, previous, before, after) can assume that they have the correct set up columns,
+ * and can focus on their specific behaviors
+ */
+module('Plugins | Queries | columns', function (hooks) {
+  setupTest(hooks);
+
+  const ALL_COLUMNS: ColumnConfig[] = [
+    { name: 'A', key: 'A' },
+    { name: 'B', key: 'B' },
+    { name: 'C', key: 'C' },
+    { name: 'D', key: 'D' },
+    { name: 'E', key: 'E' },
+    { name: 'F', key: 'F' },
+    { name: 'G', key: 'G' },
+  ];
+
+  function create<T>(Klass: Constructable<T>, owner: Owner) {
+    let instance = new Klass();
+
+    setOwner(instance, owner);
+
+    return instance;
+  }
+
+  function keysOf(columns: Array<{ key: string }>) {
+    return columns.map((column) => column.key);
+  }
+
+  /**
+   * SCENARIO: with one plugin
+   */
+  const ONE_HIDDEN_COLUMN: ColumnConfig[] = [
+    { name: 'A', key: 'A' },
+    { name: 'B', key: 'B' },
+    { name: 'C', key: 'C' },
+    {
+      name: 'D',
+      key: 'D',
+      pluginOptions: [ColumnVisibility.forColumn(() => ({ isVisible: false }))],
+    },
+    { name: 'E', key: 'E' },
+    { name: 'F', key: 'F' },
+    { name: 'G', key: 'G' },
+  ];
+
+  class OnePlugin {
+    table = headlessTable(this, {
+      columns: () => ONE_HIDDEN_COLUMN,
+      data: () => DATA,
+      plugins: [ColumnVisibility],
+    });
+  }
+
+  const ONE_PLUGIN_EXPECTED_VISIBLE = ONE_HIDDEN_COLUMN.filter((column) => column.key !== 'D');
+
+  module('columns.for', function () {
+    /**
+     * SCENARIO: with no plugins
+     */
+    class NoPlugins {
+      table = headlessTable(this, {
+        columns: () => ALL_COLUMNS,
+        data: () => DATA,
+      });
+    }
+
+    module('table has no plugins', function () {
+      test('without a requesting plugin, returns all columns', async function (assert) {
+        let context = create(NoPlugins, this.owner);
+        let result = columns.for(context.table);
+
+        assert.strictEqual(result.length, ALL_COLUMNS.length);
+        assert.deepEqual(keysOf(result), keysOf(ALL_COLUMNS), 'order is preserved');
+      });
+
+      test('with a requesting plugin, an error is thrown', async function (assert) {
+        assert.throws(
+          () => {
+            let context = create(NoPlugins, this.owner);
+
+            columns.for(context.table, ColumnResizing);
+          },
+          /\[ColumnResizing\] requested columns from the table, but the plugin, ColumnResizing, is not used in this table/,
+          'correct error message is used'
+        );
+      });
+    });
+
+    module('with a single plugin', function () {
+      test('without a requesting plugin, returns the columns as declared by the plugin that implements the .columns API', async function (assert) {
+        let context = create(OnePlugin, this.owner);
+        let result = columns.for(context.table);
+
+        assert.strictEqual(result.length, ONE_PLUGIN_EXPECTED_VISIBLE.length);
+        assert.strictEqual(result.length, ONE_HIDDEN_COLUMN.length - 1, 'one column is hidden');
+        assert.deepEqual(
+          keysOf(result),
+          keysOf(ONE_PLUGIN_EXPECTED_VISIBLE),
+          'columns from ColumnVisibility are used'
+        );
+      });
+
+      test('with a requesting plugin, returns all columns', async function (assert) {
+        let context = create(OnePlugin, this.owner);
+        let result = columns.for(context.table, ColumnVisibility);
+
+        assert.strictEqual(result.length, ALL_COLUMNS.length, 'one column is hidden');
+        assert.deepEqual(keysOf(result), keysOf(ALL_COLUMNS));
+      });
+
+      test('requesting plugin is not present in this table, and an error is thrown', async function (assert) {
+        assert.throws(
+          () => {
+            let context = create(OnePlugin, this.owner);
+
+            columns.for(context.table, ColumnResizing);
+          },
+          /\[ColumnResizing\] requested columns from the table, but the plugin, ColumnResizing, is not used in this table/,
+          'correct error message is used'
+        );
+      });
+    });
+
+    module('Using many of the plugins provided by ember-headless-table', function (hooks) {
+      /**
+       * SCENARIO: with plugins
+       * This plugin graph looks like:
+       *
+       * [raw table columns]
+       *       ^
+       *       |
+       *  ColumnVisibility
+       *      ^
+       *      |
+       *  ColumnReordering
+       *      ^          /-------> columns requests with no requirements get shoved to the bottom of the graph
+       *      \ > ------/
+       *      ^\           ---- ColumnResizing
+       *      | \        /      ^
+       *      |  ^------       / via `requires`
+       *     |    \           /
+       *    |      StickyColumns
+       *   |
+       *  DataSorting -- does not define requirements, so it gets shoved to the bottom of the graph
+       */
+      class Plugins {
+        table = headlessTable(this, {
+          columns: () => ALL_COLUMNS,
+          data: () => DATA,
+          plugins: [ColumnReordering, ColumnVisibility, ColumnResizing, StickyColumns, DataSorting],
+        });
+      }
+
+      let table: Table;
+
+      hooks.beforeEach(function (assert) {
+        table = create(Plugins, this.owner).table;
+
+        /**
+         * Perform some operations on the columns so that we can know
+         * which set of columsn we're getting
+         */
+        let [first, second, third] = table.columns;
+
+        debugAssert(`Missing columns`, first && second && third);
+
+        meta.forColumn(first, ColumnVisibility).hide();
+
+        assert.deepEqual(
+          keysOf(meta.forTable(table, ColumnVisibility).visibleColumns),
+          ['B', 'C', 'D', 'E', 'F', 'G'],
+          'setup: the first column is hidden'
+        );
+        meta.forColumn(third, ColumnReordering).moveLeft();
+
+        assert.deepEqual(
+          keysOf(meta.forTable(table, ColumnReordering).columns),
+          ['C', 'B', 'D', 'E', 'F', 'G'],
+          'setup: column C (the third), has moved to the left'
+        );
+
+        meta.forColumn(second, ColumnReordering).moveRight();
+
+        assert.deepEqual(
+          keysOf(meta.forTable(table, ColumnReordering).columns),
+          ['C', 'D', 'B', 'E', 'F', 'G'],
+          'setup: column B (the second, originally), has moved to the right'
+        );
+      });
+
+      test(`the root plugin gets the table's columns`, function (assert) {
+        assert.deepEqual(keysOf(columns.for(table, ColumnVisibility)), [
+          'A',
+          'B',
+          'C',
+          'D',
+          'E',
+          'F',
+          'G',
+        ]);
+      });
+
+      test(`The second plugin in the hierarchy gets the columns from the root Plugin`, function (assert) {
+        assert.deepEqual(keysOf(columns.for(table, ColumnReordering)), [
+          'B',
+          'C',
+          'D',
+          'E',
+          'F',
+          'G',
+        ]);
+      });
+
+      test('ColumnResizing: all other plugins get the same column set', function (assert) {
+        assert.deepEqual(keysOf(columns.for(table, ColumnResizing)), [
+          'C',
+          'D',
+          'B',
+          'E',
+          'F',
+          'G',
+        ]);
+      });
+
+      test('DataSorting: all other plugins get the same column set', function (assert) {
+        assert.deepEqual(keysOf(columns.for(table, DataSorting)), ['C', 'D', 'B', 'E', 'F', 'G']);
+      });
+
+      test('StickyColumns: all other plugins get the same column set', function (assert) {
+        assert.deepEqual(keysOf(columns.for(table, StickyColumns)), ['C', 'D', 'B', 'E', 'F', 'G']);
+      });
+
+      test(`Without a requesting plugin, the columns are the same as the leaf-plugins' columns`, function (assert) {
+        assert.deepEqual(keysOf(columns.for(table)), ['C', 'D', 'B', 'E', 'F', 'G']);
+      });
+    });
+  });
+
+  module('columns.next', function (hooks) {
+    let table: Table;
+
+    hooks.beforeEach(function () {
+      let context = create(OnePlugin, this.owner);
+
+      table = context.table;
+    });
+
+    test('second column is returned when the reference column is the first column', function (assert) {
+      let [first, second] = table.columns;
+
+      debugAssert('first and second columns are missing', first && second);
+
+      let result = columns.next(first);
+
+      assert.strictEqual(result?.key, second.key);
+    });
+
+    test('third column is returned when the reference column is the second column', function (assert) {
+      let [, second, third] = table.columns;
+
+      debugAssert('second and third columns are missing', second && third);
+
+      let result = columns.next(second);
+
+      assert.strictEqual(result?.key, third.key);
+    });
+
+    test('plugin hierarchy is respected', function (assert) {
+      let [, , third, , fifth] = table.columns;
+
+      debugAssert('third and fifth columns are missing', third && fifth);
+
+      let result = columns.next(third);
+
+      assert.strictEqual(result?.key, fifth.key);
+    });
+
+    test('undefined is returned when the reference column is the last column', function (assert) {
+      let [last] = table.columns.values().reverse();
+
+      debugAssert('last column is missing', last);
+
+      let result = columns.next(last);
+
+      assert.strictEqual(result, undefined);
+    });
+  });
+
+  module('columns.previous', function (hooks) {
+    let table: Table;
+
+    hooks.beforeEach(function () {
+      let context = create(OnePlugin, this.owner);
+
+      table = context.table;
+    });
+
+    test('second to last column is returned when the reference column is the last column', function (assert) {
+      let [last, secondToLast] = table.columns.values().reverse();
+
+      debugAssert('last and second to last columns are missing', last && secondToLast);
+
+      let result = columns.previous(last);
+
+      assert.strictEqual(result?.key, secondToLast.key);
+    });
+
+    test('plugin hierarchy is respected', function (assert) {
+      let [, , third, , fifth] = table.columns;
+
+      debugAssert('third and fifth columns are missing', third && fifth);
+
+      let result = columns.previous(fifth);
+
+      assert.strictEqual(result?.key, third.key);
+    });
+
+    test('second column is returned when the reference column is the third column', function (assert) {
+      let [, second, third] = table.columns;
+
+      debugAssert('second and third columns are missing', second && third);
+
+      let result = columns.previous(third);
+
+      assert.strictEqual(result?.key, second.key);
+    });
+
+    test('undefined is returned when the reference column is the first column', function (assert) {
+      let [first] = table.columns;
+
+      debugAssert('first column is missing', first);
+
+      let result = columns.previous(first);
+
+      assert.strictEqual(result, undefined);
+    });
+  });
+
+  module('columns.before', function (hooks) {
+    let table: Table;
+
+    hooks.beforeEach(function () {
+      let context = create(OnePlugin, this.owner);
+
+      table = context.table;
+    });
+
+    test('empty array is returned when the reference column is the first column', function (assert) {
+      let [first] = table.columns;
+
+      debugAssert('first column is missing', first);
+
+      let result = columns.before(first);
+
+      assert.deepEqual(result.length, 0);
+      assert.deepEqual(result, []);
+    });
+
+    test('plugin hierarchy is respected', function (assert) {
+      let fifth = table.columns[4];
+
+      debugAssert('fifth column is missing', fifth);
+
+      let result = columns.before(fifth);
+
+      assert.deepEqual(keysOf(result), ['A', 'B', 'C'], 'column D is excluded');
+    });
+
+    test('for a requesting plugin, columns to the left/before of the reference column are returned', function (assert) {
+      let fifth = table.columns[4];
+
+      debugAssert('fifth column is missing', fifth);
+
+      let result = columns.before(fifth, ColumnVisibility);
+
+      assert.deepEqual(keysOf(result), ['A', 'B', 'C', 'D'], 'column D is included');
+    });
+
+    test('all but the last column is returned when the reference column is the last column', function (assert) {
+      let [last] = table.columns.values().reverse();
+
+      debugAssert('last column is missing', last);
+
+      let result = columns.before(last);
+
+      assert.deepEqual(keysOf(result), ['A', 'B', 'C', 'E', 'F']);
+    });
+  });
+
+  module('columns.after', function (hooks) {
+    let table: Table;
+
+    hooks.beforeEach(function () {
+      let context = create(OnePlugin, this.owner);
+
+      table = context.table;
+    });
+
+    test('empty array is returned when the reference column is the last column', function (assert) {
+      let [last] = table.columns.values().reverse();
+
+      debugAssert('last column is missing', last);
+
+      let result = columns.after(last);
+
+      assert.deepEqual(result.length, 0);
+      assert.deepEqual(result, []);
+    });
+
+    test('plugin hierarchy is respected', function (assert) {
+      let third = table.columns[2];
+
+      debugAssert('third column is missing', third);
+
+      let result = columns.after(third);
+
+      assert.deepEqual(keysOf(result), ['E', 'F', 'G'], 'column D is skipped, due to plugins');
+    });
+
+    test('for a requesting plugin, columns to the right/after of the reference column are returned', function (assert) {
+      let third = table.columns[2];
+
+      debugAssert('third column is missing', third);
+
+      let result = columns.after(third, ColumnVisibility);
+
+      assert.deepEqual(keysOf(result), ['D', 'E', 'F', 'G'], 'column D is included');
+    });
+
+    test('all but the first column is returned when the reference column is the first column', function (assert) {
+      let first = table.columns[0];
+
+      debugAssert('first column is missing', first);
+
+      let result = columns.after(first);
+
+      assert.deepEqual(keysOf(result), ['B', 'C', 'E', 'F', 'G']);
+    });
+  });
+});

--- a/test-app/tests/plugins/queries/columns-test.ts
+++ b/test-app/tests/plugins/queries/columns-test.ts
@@ -182,7 +182,7 @@ module('Plugins | Queries | columns', function (hooks) {
 
         /**
          * Perform some operations on the columns so that we can know
-         * which set of columsn we're getting
+         * which set of columns we're getting
          */
         let [first, second, third] = table.columns;
 
@@ -322,7 +322,7 @@ module('Plugins | Queries | columns', function (hooks) {
     test('second to last column is returned when the reference column is the last column', function (assert) {
       let [last, secondToLast] = table.columns.values().reverse();
 
-      debugAssert('last and second to last columns are missing', last && secondToLast);
+      debugAssert('last and/or second to last columns are missing', last && secondToLast);
 
       let result = columns.previous(last);
 
@@ -332,7 +332,7 @@ module('Plugins | Queries | columns', function (hooks) {
     test('plugin hierarchy is respected', function (assert) {
       let [, , third, , fifth] = table.columns;
 
-      debugAssert('third and fifth columns are missing', third && fifth);
+      debugAssert('third and/or fifth columns are missing', third && fifth);
 
       let result = columns.previous(fifth);
 
@@ -342,7 +342,7 @@ module('Plugins | Queries | columns', function (hooks) {
     test('second column is returned when the reference column is the third column', function (assert) {
       let [, second, third] = table.columns;
 
-      debugAssert('second and third columns are missing', second && third);
+      debugAssert('second and/or third columns are missing', second && third);
 
       let result = columns.previous(third);
 
@@ -376,7 +376,7 @@ module('Plugins | Queries | columns', function (hooks) {
 
       let result = columns.before(first);
 
-      assert.deepEqual(result.length, 0);
+      assert.strictEqual(result.length, 0);
       assert.deepEqual(result, []);
     });
 
@@ -427,7 +427,7 @@ module('Plugins | Queries | columns', function (hooks) {
 
       let result = columns.after(last);
 
-      assert.deepEqual(result.length, 0);
+      assert.strictEqual(result.length, 0);
       assert.deepEqual(result, []);
     });
 

--- a/test-app/tests/unit/public-api-test.ts
+++ b/test-app/tests/unit/public-api-test.ts
@@ -35,6 +35,7 @@ module('Public API', function () {
       [
         // Utilities
         'BasePlugin',
+        'columns',
         'meta',
         'options',
         'preferences',


### PR DESCRIPTION
This was a feature request / feedback from @vitch a while back when we were first open sourcing this library.

---------------

## Motivation

Prior to this PR, working with columns from the plugins in a hierarchical way leaked the hierarchy between the plugins, preventing consistent use of columns APIs for the consumer -- a plugin author would need to know the hierarchy, and know which plugin to access to get the correct columns.

This has now all bee abstracted away in a new set of queries helpers called `columns`.

---------------

Requires: https://github.com/CrowdStrike/ember-headless-table/pull/12

- ~~implement "optionally requires" to imply a hierarchy, as hard-requiring another plugin to be used "should be" rare~~ can be done in a later PR, when the need arises
- [x] implement helpers
   - [x] `columnsForPlugin(table, requestingPlugin)`
       gets the columns appropriate for the requesting plugin - automatically figures out plugin hierarchy
   - [x] these helpers are plugin-relative, based on `columnsForPlugin` (but that's an implementation detail)
      - [x] `nextColumn(focusedColumn, requestingPlugin)`
      - [x] `previousColumn(focusedColumn, requestingPlugin)`
      - [x] `columnsAfter(column, requestingPlugin)`
      - [x] `columnsBefore(column, requestingPlugin)`
- [x] ensure that all plugins can be used in isolation
   - [x] `ColumnResizing`
   - [x] `StickyColumns`
   - [x] `ColumnReordering`
   - [x] `ColumnResizing`
   
   
 ## For review 

First, you'll want to look at the tests, in particular for ColumnReordering and ColumnResizing -- these are refactors that were enabled after all the above was implemented.

Then, you'll want to read through the changes to plugin/-private/base.ts, and then see how those changes had an effect on each plugin.  

I'm hesitant to update the demos to match the tests now, because the non-gjs ergonomics are really sub-par, and I need to add gjs/gts support to Docfy. I have minimally updated the demos that were directly accessing plugins' Meta to get the columns tho.