### PR TITLE
Fix resizing column logic

### DIFF
--- a/docs/plugins/column-resizing/demo/demo-a.md
+++ b/docs/plugins/column-resizing/demo/demo-a.md
@@ -40,6 +40,7 @@ import { htmlSafe } from '@ember/template';
 import { headlessTable } from 'ember-headless-table';
 import { meta } from 'ember-headless-table/plugins';
 import { ColumnVisibility } from 'ember-headless-table/plugins/column-visibility';
+import { ColumnReordering } from 'ember-headless-table/plugins/column-reordering';
 import { ColumnResizing, resizeHandle, isResizing } from 'ember-headless-table/plugins/column-resizing';
 
 import { DATA } from 'docs-app/sample-data';
@@ -62,6 +63,7 @@ export default class extends Component {
     data: () => DATA,
     plugins: [
       ColumnVisibility,
+      ColumnReordering,
       ColumnResizing,
     ],
   });

--- a/ember-headless-table/src/plugins/column-reordering/plugin.ts
+++ b/ember-headless-table/src/plugins/column-reordering/plugin.ts
@@ -160,6 +160,59 @@ export class TableMeta {
     return this.columnOrder.orderedColumns;
   }
 
+  previousColumn = (referenceColumn: Column) => {
+    let visible = this.columns;
+    let referenceIndex = visible.indexOf(referenceColumn);
+
+    assert(
+      `index of reference column must be >= 0. column likely not a part of the table`,
+      referenceIndex >= 0
+    );
+
+    /**
+     * There can be nothing before the first column
+     */
+    if (referenceIndex === 0) {
+      return null;
+    }
+
+    return visible[referenceIndex - 1];
+  }
+
+  nextColumn = (referenceColumn: Column) => {
+    let visible = this.columns;
+    let referenceIndex = visible.indexOf(referenceColumn);
+
+    assert(
+      `index of reference column must be >= 0. column likely not a part of the table`,
+      referenceIndex >= 0
+    );
+
+    /**
+     * There can be nothing after the last column
+     */
+    if (referenceIndex > visible.length - 1) {
+      return null;
+    }
+
+    return visible[referenceIndex + 1];
+  }
+
+  columnsAfter = (referenceColumn: Column) => {
+    let visible = this.columns;
+    let referenceIndex = visible.indexOf(referenceColumn);
+
+    return visible.slice(referenceIndex + 1);
+  }
+
+  columnsBefore = (referenceColumn: Column) => {
+    let visible = this.columns;
+    let referenceIndex = visible.indexOf(referenceColumn);
+
+    return visible.slice(0, referenceIndex);
+  }
+
+
   /**
    * @private
    * This isn't our data to expose, but it is useful to alias

--- a/ember-headless-table/src/plugins/column-reordering/plugin.ts
+++ b/ember-headless-table/src/plugins/column-reordering/plugin.ts
@@ -177,7 +177,7 @@ export class TableMeta {
     }
 
     return visible[referenceIndex - 1];
-  }
+  };
 
   nextColumn = (referenceColumn: Column) => {
     let visible = this.columns;
@@ -196,22 +196,21 @@ export class TableMeta {
     }
 
     return visible[referenceIndex + 1];
-  }
+  };
 
   columnsAfter = (referenceColumn: Column) => {
     let visible = this.columns;
     let referenceIndex = visible.indexOf(referenceColumn);
 
     return visible.slice(referenceIndex + 1);
-  }
+  };
 
   columnsBefore = (referenceColumn: Column) => {
     let visible = this.columns;
     let referenceIndex = visible.indexOf(referenceColumn);
 
     return visible.slice(0, referenceIndex);
-  }
-
+  };
 
   /**
    * @private

--- a/ember-headless-table/src/plugins/column-resizing/plugin.ts
+++ b/ember-headless-table/src/plugins/column-resizing/plugin.ts
@@ -154,7 +154,7 @@ export class ColumnMeta {
   }
 
   get hasResizeHandle() {
-    let visiblility = meta.withFeature.forTable(this.column.table, 'columnVisibility');
+    let visiblility = meta.withFeature.forTable(this.column.table, 'columnOrder');
     let previous = visiblility.previousColumn(this.column);
 
     if (!previous) return false;
@@ -249,14 +249,14 @@ export class TableMeta {
     );
   }
 
-  get visibleColumns() {
-    let visiblility = meta.withFeature.forTable(this.table, 'columnVisibility');
+  get #availableColumns() {
+    let otherTableMeta = meta.withFeature.forTable(this.table, 'columnOrder');
 
-    return visiblility.visibleColumns;
+    return otherTableMeta.columns;
   }
 
   get visibleColumnMetas() {
-    return this.visibleColumns.map((column) => meta.forColumn(column, ColumnResizing));
+    return this.#availableColumns.map((column) => meta.forColumn(column, ColumnResizing));
   }
 
   get totalInitialColumnWidths() {
@@ -293,7 +293,7 @@ export class TableMeta {
     let totalGap = totalGapOf(entry.target.querySelector('[role="row"]'));
     let diff = this.scrollContainerWidth - this.totalVisibleColumnsWidth - totalGap;
 
-    distributeDelta(diff, this.visibleColumns);
+    distributeDelta(diff, this.#availableColumns);
   }
 
   @action
@@ -320,7 +320,7 @@ export class TableMeta {
     let position = this.options?.handlePosition ?? 'left';
 
     let growingColumn: Column | null | undefined;
-    let visiblility = meta.withFeature.forTable(this.table, 'columnVisibility');
+    let visiblility = meta.withFeature.forTable(this.table, 'columnOrder');
 
     if (position === 'right') {
       growingColumn = isDraggingRight ? visiblility.nextColumn(column) : column;

--- a/test-app/tests/plugins/sticky-columns/rendering-test.gts
+++ b/test-app/tests/plugins/sticky-columns/rendering-test.gts
@@ -8,6 +8,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { headlessTable, type ColumnConfig } from 'ember-headless-table';
 import { ColumnVisibility } from 'ember-headless-table/plugins/column-visibility';
 import { StickyColumns, isSticky } from 'ember-headless-table/plugins/sticky-columns';
+import { ColumnReordering } from 'ember-headless-table/plugins/column-reordering';
 import { ColumnResizing } from 'ember-headless-table/plugins/column-resizing';
 import { createHelpers } from 'ember-headless-table/test-support';
 import { DATA } from 'test-app/data';
@@ -82,7 +83,7 @@ module('Plugins | StickyColumns', function (hooks) {
     table = headlessTable(this, {
       columns: () => this.columns,
       data: () => DATA,
-      plugins: [ColumnVisibility, ColumnResizing, StickyColumns],
+      plugins: [ColumnVisibility, ColumnReordering, ColumnResizing, StickyColumns],
     });
   }
 


### PR DESCRIPTION
Requires https://github.com/CrowdStrike/ember-headless-table/pull/12
(will make the diff actually understandable)

Will be made simpler by: https://github.com/CrowdStrike/ember-headless-table/pull/40
(but that's not required by this work, and can lead to a nice _delete a bunch of things PR_ later