### PR TITLE
chore(internal): setup turborepo

### DIFF
--- a/.github/actions/assert-build/action.yml
+++ b/.github/actions/assert-build/action.yml
@@ -10,7 +10,7 @@ runs:
         target: ${{ env.dist }}
         setup:
           run: pnpm build
-          cwd: ./ember-headless-table
+          cwd: ./
         expect: |
           index.js
           index.js.map
@@ -22,7 +22,7 @@ runs:
           plugins/column-visibility/index.js
           plugins/sticky-columns/index.js
           test-support/index.js
-          
+
       ' >> assert-contents.config.yml
       npx assert-folder-contents
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: TurboRepo local server
+        uses: felixmosh/turborepo-gh-artifacts@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          server-token: foo-123
       - uses: ./.github/actions/pnpm
 
 
@@ -32,7 +37,13 @@ jobs:
     needs: [install_dependencies]
     steps:
       - uses: actions/checkout@v3
+      - name: TurboRepo local server
+        uses: felixmosh/turborepo-gh-artifacts@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          server-token: foo-123
       - uses: ./.github/actions/pnpm
+      - run: pnpm install
       - name: Lint
         run: pnpm lint
 
@@ -45,7 +56,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: TurboRepo local server
+        uses: felixmosh/turborepo-gh-artifacts@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          server-token: foo-123
       - uses: ./.github/actions/pnpm
+      - run: pnpm install
       - uses: ./.github/actions/assert-build
 
 
@@ -67,20 +84,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: TurboRepo local server
+        uses: felixmosh/turborepo-gh-artifacts@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          server-token: foo-123
       - uses: ./.github/actions/pnpm
-      - uses: ./.github/actions/download-built-package
       - name: 'Change TS to ${{ matrix.typescript-scenario }}'
         run: 'pnpm add --save-dev ${{ matrix.typescript-scenario}}'
         working-directory: ./test-app
+      - run: pnpm install
       - name: 'Type checking'
-
-        run: |
-          pnpm --filter test-app exec tsc -v;
-          pnpm --filter test-app exec glint --version;
-          pnpm --filter test-app exec glint;
-
-
-
+        run: 'pnpm _turbo --filter test-app typecheck;'
 
 
   default_tests:
@@ -90,9 +105,14 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@v3
+      - name: TurboRepo local server
+        uses: felixmosh/turborepo-gh-artifacts@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          server-token: foo-123
       - uses: ./.github/actions/pnpm
-      - uses: ./.github/actions/download-built-package
-      - run: pnpm --filter test-app test:ember
+      - run: pnpm install
+      - run: pnpm _turbo --filter test-app test
 
   floating_tests:
     name: Floating Deps Test
@@ -101,10 +121,15 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@v3
+      - name: TurboRepo local server
+        uses: felixmosh/turborepo-gh-artifacts@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          server-token: foo-123
       - uses: ./.github/actions/pnpm
       - name: Install Dependencies (without lockfile)
         run: rm pnpm-lock.yaml && pnpm install
-      - uses: ./.github/actions/download-built-package
+      - run: pnpm install
       - run: pnpm --filter test-app test:ember
 
 
@@ -133,20 +158,25 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: TurboRepo local server
+        uses: felixmosh/turborepo-gh-artifacts@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          server-token: foo-123
       - uses: ./.github/actions/pnpm
-      - uses: ./.github/actions/download-built-package
-      - name: Run Tests
+      - name: "Setup scenario: ${{ matrix.try-scenario }}"
         working-directory: ./test-app
         run: |
           if [[ "${{matrix.try-scenario}}" == "'ember-lts-4.8 + embroider-optimized'" ]]; then
             echo 'Running custom try scenario due to peer deps resolving incorrectly (due to installation issues)'
             pnpm add --save-dev ember-source@~4.8.0
             pnpm add --save-dev @embroider/core @embroider/webpack @embroider/compat
-            pnpm ember test
+            # pnpm ember test
           else
-            node_modules/.bin/ember try:one ${{ matrix.try-scenario }} --skip-cleanup
+            node_modules/.bin/ember try:one ${{ matrix.try-scenario }} --skip-cleanup --- echo "setup"
           fi
-
+      - name: "Run tests"
+        run: pnpm _turbo --filter="test-app" test
 
 
 
@@ -188,11 +218,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+      - name: TurboRepo local server
+        uses: felixmosh/turborepo-gh-artifacts@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          server-token: foo-123
       - uses: ./.github/actions/pnpm
-      - uses: ./.github/actions/download-built-package
-      - run: pnpm glint
-        working-directory: docs-app
-
+      - run: pnpm install
+      - run: pnpm _turbo --filter docs-app typecheck
 
 
   PublishDocstoCloudflarePages:
@@ -209,9 +242,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+      - name: TurboRepo local server
+        uses: felixmosh/turborepo-gh-artifacts@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          server-token: foo-123
       - uses: ./.github/actions/pnpm
-      - uses: ./.github/actions/download-built-package
-      - run: pnpm build:docs
+      - run: pnpm install
+      - run: pnpm _turbo --filter docs-api build
       - name: Publish to Cloudflare Pages
         id: publishStep
         uses: cloudflare/pages-action@1
@@ -233,7 +271,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/pnpm
-      - uses: ./.github/actions/download-built-package
       - uses: marocchino/sticky-pull-request-comment@v2
         with:
           message: |+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 .DS_Store
+.turbo
 
 # compiled output
 dist/

--- a/docs-api/package.json
+++ b/docs-api/package.json
@@ -1,11 +1,10 @@
 {
   "name": "docs-api",
   "version": "0.0.0",
-  "private": true,
   "scripts": {
     "start": "pnpm docs:watch",
-    "docs:build": "typedoc --options ./typedoc.config.json",
-    "docs:watch": "typedoc --options ./typedoc.config.json --watch"
+    "docs:watch": "typedoc --options ./typedoc.config.json --watch",
+    "build": "typedoc --options ./typedoc.config.json && mkdir -p ../docs-app/dist/api && cp ./dist ../docs-app/dist/api -r"
   },
   "devDependencies": {
     "typedoc": "^0.23.23",
@@ -14,6 +13,11 @@
     "typedoc-plugin-markdown": "^3.14.0",
     "typedoc-plugin-markdown-pages": "^0.3.0",
     "typedoc-plugin-mdn-links": "^2.0.2",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.4",
+    "ember-headless-table": "workspace:../ember-headless-table",
+    "docs-app": "workspace:../docs-app"
+  },
+  "publishConfig": {
+    "registry": "https://noop.noop.noop"
   }
 }

--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -12,14 +12,14 @@
   },
   "scripts": {
     "build": "ember build --environment=production",
-    "lint": "concurrently 'npm:lint:*(!fix)' --names 'lint:' --prefix-colors cyan,white,yellow",
     "lint:fix": "concurrently 'npm:lint:*:fix' --names 'fix:' --prefix-colors cyan,white,yellow",
     "lint:hbs": "ember-template-lint . --no-error-on-unmatched-pattern",
     "lint:js": "eslint . --cache",
     "lint:hbs:fix": "ember-template-lint . --fix --no-error-on-unmatched-pattern",
     "lint:js:fix": "eslint . --fix",
     "start": "ember serve",
-    "test:ember": "ember test"
+    "test:ember": "ember test",
+    "typecheck": "echo \"TSC: $( pnpm tsc --version )\"; echo \"Glint: $( glint --version )\"; glint --build"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",

--- a/ember-headless-table/package.json
+++ b/ember-headless-table/package.json
@@ -24,9 +24,9 @@
     "./plugins/column-visibility": "./dist/plugins/column-visibility/index.js",
     "./plugins/sticky-columns": "./dist/plugins/sticky-columns/index.js",
     "./plugins/row-selection": "./dist/plugins/row-selection/index.js",
-    "./plugins/metadata": "./dist/plugins/metadata/index.js",
     "./test-support": "./dist/test-support/index.js",
-    "./addon-main.js": "./addon-main.js"
+    "./addon-main.js": "./addon-main.js",
+    "./plugins/metadata": "./dist/plugins/metadata/index.js"
   },
   "typesVersions": {
     "*": {
@@ -51,20 +51,19 @@
       "plugins/row-selection": [
         "./dist/plugins/row-selection/index.d.ts"
       ],
-      "plugins/metadata": [
-        "./dist/plugins/metadata/index.d.ts"
-      ],
       "test-support": [
         "./dist/test-support/index.d.ts"
       ],
       "*": [
         "./dist/*"
+      ],
+      "plugins/metadata": [
+        "./dist/plugins/metadata/index.d.ts"
       ]
     }
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
-    "lint": "concurrently 'npm:lint:*(!fix)' --names 'lint:'",
     "lint:fix": "concurrently 'npm:lint:*:fix' --names 'fix:'",
     "lint:hbs": "ember-template-lint . --no-error-on-unmatched-pattern",
     "lint:js": "eslint . --cache",
@@ -93,11 +92,11 @@
     "@babel/runtime": "^7.17.8",
     "@ember/string": "^3.0.0",
     "@embroider/addon-shim": "^1.0.0",
-    "@embroider/macros": "1.10.0",
     "ember-modifier": "^3.2.7",
     "ember-resources": "^5.4.0",
     "ember-tracked-storage-polyfill": "^1.0.0",
-    "tracked-built-ins": "^3.1.0"
+    "tracked-built-ins": "^3.1.0",
+    "@embroider/macros": "1.10.0"
   },
   "devDependencies": {
     "@babel/core": "^7.17.0",

--- a/package.json
+++ b/package.json
@@ -6,32 +6,33 @@
   "license": "MIT",
   "author": "",
   "scripts": {
-    "release": "changeset publish",
-    "build": "pnpm --filter ember-headless-table build",
-    "build:docs": "pnpm build:docs-app && pnpm build:docs-api && cp ./docs-api/dist ./docs-app/dist/api -r",
-    "build:docs-app": "pnpm --filter docs-app build",
-    "build:docs-api": "pnpm --filter docs-api docs:build",
+    "build": "pnpm _turbo --filter ember-headless-table build",
     "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
-    "start:tests": "pnpm --filter ember-headless-table start",
+    "start:tests": "pnpm --filter test-app start",
     "start:addon": "pnpm --filter ember-headless-table start --no-watch.clearScreen",
     "start:docs-api": "pnpm --filter 'docs-api' docs:watch --preserveWatchOutput",
     "start:docs-app": "pnpm --filter 'docs-app' start -p 4201",
     "ci:update": "npx ember-ci-update",
-    "test": "pnpm --filter ember-headless-table test",
-    "lint": "pnpm --filter '*' lint",
-    "lint:fix": "pnpm --filter '*' lint:fix"
+    "test": "pnpm _turbo test",
+    "lint": "pnpm _turbo lint",
+    "lint:fix": "pnpm _turbo lint --fix",
+    "release": "changeset publish",
+    "prepare": "pnpm build",
+    "dev": "pnpm start",
+    "_turbo": "pnpm turbo --api='http://127.0.0.1:9080' --token=foo-123 --team=foo"
   },
   "devDependencies": {
-    "@changesets/changelog-github": "^0.4.8",
-    "@changesets/cli": "^2.26.0",
     "concurrently": "^7.6.0",
-    "prettier": "^2.8.2"
+    "prettier": "^2.8.2",
+    "turbo": "^1.6.1",
+    "@changesets/cli": "^2.26.0",
+    "@changesets/changelog-github": "^0.4.8"
   },
   "pnpm": {
     "overrides": {
       "@types/eslint": "^7.0.0",
-      "@embroider/macros": "1.10.0",
-      "ember-auto-import": "^2.4.2"
+      "ember-auto-import": "^2.4.2",
+      "@embroider/macros": "1.10.0"
     },
     "overrides-notes": {
       "@types/eslint": "webpack brings in v8, but we use v7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,8 +2,8 @@ lockfileVersion: 5.4
 
 overrides:
   '@types/eslint': ^7.0.0
-  '@embroider/macros': 1.10.0
   ember-auto-import: ^2.4.2
+  '@embroider/macros': 1.10.0
 
 importers:
 
@@ -13,14 +13,18 @@ importers:
       '@changesets/cli': ^2.26.0
       concurrently: ^7.6.0
       prettier: ^2.8.2
+      turbo: ^1.6.1
     devDependencies:
       '@changesets/changelog-github': 0.4.8
       '@changesets/cli': 2.26.0
       concurrently: 7.6.0
       prettier: 2.8.2
+      turbo: 1.6.1
 
   docs-api:
     specifiers:
+      docs-app: workspace:../docs-app
+      ember-headless-table: workspace:../ember-headless-table
       typedoc: ^0.23.23
       typedoc-github-wiki-theme: ^1.0.1
       typedoc-gitlab-wiki-theme: ^1.0.0
@@ -29,6 +33,8 @@ importers:
       typedoc-plugin-mdn-links: ^2.0.2
       typescript: ^4.9.4
     devDependencies:
+      docs-app: link:../docs-app
+      ember-headless-table: link:../ember-headless-table
       typedoc: 0.23.23_typescript@4.9.4
       typedoc-github-wiki-theme: 1.0.1_e5d6zdlrllhuqvr7rr6w7fp65a
       typedoc-gitlab-wiki-theme: 1.0.0_e5d6zdlrllhuqvr7rr6w7fp65a
@@ -13756,12 +13762,12 @@ packages:
     resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+    dev: true
 
   /prettier/2.8.2:
     resolution: {integrity: sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
-    dev: true
 
   /pretty-hrtime/1.0.3:
     resolution: {integrity: sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==}
@@ -14209,7 +14215,7 @@ packages:
       '@babel/core': 7.20.12
       '@babel/plugin-syntax-decorators': 7.19.0_@babel+core@7.20.12
       '@babel/plugin-transform-typescript': 7.20.2_@babel+core@7.20.12
-      prettier: 2.7.1
+      prettier: 2.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -15807,6 +15813,67 @@ packages:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
       yargs: 17.6.2
+    dev: true
+
+  /turbo-darwin-64/1.6.1:
+    resolution: {integrity: sha512-xsItJ/hmnd6R8V60cCe0RAZQjO+En/LVXVkZhiw0Fyfxoo+iKcAA4sVeWkaL+cg5sQd5UWlWfD1EOKbHDjVb9Q==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-darwin-arm64/1.6.1:
+    resolution: {integrity: sha512-wRfAJWCLYB29IGTx6sF6QvexK/89AbAgnfYA5yVcuUJT+xz2/zLeGcOODQBCnP4rB+vX5ipXLY0XjkLGl+z6fA==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-linux-64/1.6.1:
+    resolution: {integrity: sha512-NZ88muC3hHbWW/cBgl9DFFbyzDcFVvZHQBXKTwVA8l2yLOOvesX+aQ2Knr4Pxu9Kb0F3t6ABsOSf8SbI7CpJsg==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-linux-arm64/1.6.1:
+    resolution: {integrity: sha512-HDgx+0ozqMpoDBOSzWz43nYMDp/+giEz8+vmLOB6mTQU/9IlZQVwachzwkqLRsJyBUhYALBlWGcuRWO3KqXMmg==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-windows-64/1.6.1:
+    resolution: {integrity: sha512-jnR0V0YBlFJKEoAeq0GQFLmZ1UNl6vh+RHTHX546+o5jKcE6nfp9oTOEwtR0PLutiuxxDDm6roAc+9mSfycffw==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo-windows-arm64/1.6.1:
+    resolution: {integrity: sha512-vOqw/iPgLjkwpni2vNFK9YO19lN9QZ8JG8v1unvL09/rnXyKpHygrYECj+efJptEVJKBG2xLIauJYmZ/2LV1Uw==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /turbo/1.6.1:
+    resolution: {integrity: sha512-CkcJo17cbwfTzmxtxJo2AbbeVqaz1yQotBUqVwZDdcrVSNKci2nvw+JHJ3sy/z9YY9xOJmoRaZifbkja3UXUWA==}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      turbo-darwin-64: 1.6.1
+      turbo-darwin-arm64: 1.6.1
+      turbo-linux-64: 1.6.1
+      turbo-linux-arm64: 1.6.1
+      turbo-windows-64: 1.6.1
+      turbo-windows-arm64: 1.6.1
     dev: true
 
   /type-check/0.3.2:

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -11,17 +11,16 @@
     "test": "tests"
   },
   "scripts": {
-    "build": "ember build --environment=production",
-    "lint": "concurrently 'npm:lint:*(!fix)' --names 'lint:' --prefix-colors cyan,white,yellow",
     "lint:fix": "concurrently 'npm:lint:*:fix' --names 'fix:' --prefix-colors cyan,white,yellow",
     "lint:hbs": "ember-template-lint . --no-error-on-unmatched-pattern",
     "lint:js": "eslint . --cache",
     "lint:hbs:fix": "ember-template-lint . --fix --no-error-on-unmatched-pattern",
     "lint:js:fix": "eslint . --fix",
     "start": "ember serve",
-    "test": "npm-run-all lint \"test:!(watch)\"",
+    "test": "ember test",
     "test:ember": "ember test",
-    "test:watch": "ember test --server"
+    "test:watch": "ember test --server",
+    "typecheck": "echo \"TSC: $( pnpm tsc --version )\"; echo \"Glint: $( glint --version )\"; glint --build"
   },
   "dependencies": {
     "@ember/test-helpers": "^2.8.1",

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "pipeline": {
+    "dev": {
+      // A package's `build` script depends on that package's
+      // dependencies and devDependencies
+      // `build` tasks  being completed first
+      // (the `^` symbol signifies `upstream`).
+      "dependsOn": ["^build"],
+      // Ignore all outputs for "dev", because we don't
+      // want to cache anything
+      "outputs": [],
+      "cache": false
+    },
+    // Alias for dev
+    "start": {
+      "dependsOn": ["dev"],
+      "outputs": [],
+      "cache": false
+    },
+    "test": {
+      // Normally, A package's `test` script depends on that package's
+      // own `build` script being completed first.
+      // But for ember apps, they build themselves during
+      // test execution, so we can only get away with only
+      // building our dependencies
+      "dependsOn": ["^build"]
+    },
+    "build": {
+      "outputs": ["dist/**"],
+      // Normally, A package's `test` script depends on that package's
+      // own `build` script being completed first.
+      // But for ember apps, they build themselves during
+      // test execution, so we can only get away with only
+      // building our dependencies
+      "dependsOn": ["^build"]
+    },
+    "lint": {
+      // A package's `lint` script has no dependencies and
+      // can be run whenever. It also has no filesystem outputs.
+      "outputs": [],
+      // "lint" is an alias for all types of linting
+      // This allows the results of eslint and ember-template-lint
+      // to be individually cached, depending on what's changed
+      "dependsOn": ["lint:js", "lint:hbs"]
+    },
+    "lint:js": {
+      // A package's `lint` script has no dependencies and
+      // can be run whenever. It also has no filesystem outputs.
+      "outputs": []
+    },
+    "lint:hbs": {
+      // A package's `lint` script has no dependencies and
+      // can be run whenever. It also has no filesystem outputs.
+      "outputs": []
+    },
+    "typecheck": {
+      // A package's `typecheck` script depends on the
+      // build of the same package
+      "dependsOn": ["build", "^build"],
+      // A package's `lint` script has no dependencies and
+      // can be run whenever. It also has no filesystem outputs.
+      "outputs": []
+    }
+  }
+}


### PR DESCRIPTION
Things to explore
- [x] by how many minutes can we reduce C.I.?
- [x] improve DX of first-time contributors / how much of CONTRIBUTING.md can we automate?

Before:
 - [Combined duration: 21m 6s](https://github.com/CrowdStrike/ember-headless-table/actions/runs/3300769543/usage)
 - [Duration: 5m 6s](https://github.com/CrowdStrike/ember-headless-table/actions/runs/3300769543)
 
After:
 - [Combined duration: 17m 38s](https://github.com/CrowdStrike/ember-headless-table/actions/runs/3315451866/usage)
 - [Duration: 4m 3s](https://github.com/CrowdStrike/ember-headless-table/actions/runs/3315451866)
 
_at the time of collecting these numbers, a lot of time is wasted due to excessive `pnpm i` runs due to the below linked issue_.
Also, the `setup-node` action takes about 18-30s for every job, so if everything was instant, this step of each job would total to  8-10m -- combined with dependencies in general taking 10s, I'm not sure how much more room for improvement there is (aside from the bug getting fix (linked below))

---------------------------------------

after a `pnpm install` , can we have X "just work"?
- [x] `pnpm start` (watch mode all the things)
- [x] `pnpm test` (cli only, no server)

until the below issue is a fixed, a `pnpm install` is required after the initial `pnpm install` to re-sync pnpm.
Once done, the following is observed:
- `pnpm test`
  - 21s initially
  - 236s subsequently
- `pnpm start` - works, no turbo needed, because `prepare` ran after install

------------------------------------

Things learned along the way:
- [ ] Bug encountered here: https://github.com/pnpm/pnpm/issues/4965
  - injected dependencies needed for deep peers to be resolved correctly, but there is no automatic re-syncing
     - work-around: none -- we can't have turbo re-apply cache and have pnpm's injection work at the same time atm.