### PR TITLE
Add more convinience APIs

### DIFF
--- a/ember-headless-table/src/plugins/column-resizing/helpers.ts
+++ b/ember-headless-table/src/plugins/column-resizing/helpers.ts
@@ -19,3 +19,13 @@ export const isResizing = (column: Column) => meta.forColumn(column, ColumnResiz
  * Does the column have room to shrink?
  */
 export const canShrink = (column: Column) => meta.forColumn(column, ColumnResizing).canShrink;
+
+/**
+ * Does the column have a resize handle?
+ * The return value of this function can be determined by
+ * - if resizing is enable for the column
+ *   - if resizing is enabled for the whole table
+ *   - or if we're asking about the first column (resize handles may only be "between" columns)
+ */
+export const hasResizeHandle = (column: Column) =>
+  meta.forColumn(column, ColumnResizing).hasResizeHandle;

--- a/ember-headless-table/src/plugins/column-resizing/helpers.ts
+++ b/ember-headless-table/src/plugins/column-resizing/helpers.ts
@@ -23,7 +23,7 @@ export const canShrink = (column: Column) => meta.forColumn(column, ColumnResizi
 /**
  * Does the column have a resize handle?
  * The return value of this function can be determined by
- * - if resizing is enable for the column
+ * - if resizing is enabled for the column
  *   - if resizing is enabled for the whole table
  *   - or if we're asking about the first column (resize handles may only be "between" columns)
  */

--- a/test-app/tests/plugins/column-resizing/rendering-test.gts
+++ b/test-app/tests/plugins/column-resizing/rendering-test.gts
@@ -13,7 +13,7 @@ import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
 
 import { headlessTable, type ColumnConfig } from 'ember-headless-table';
-import { ColumnResizing, resizeHandle } from 'ember-headless-table/plugins/column-resizing';
+import { ColumnResizing, resizeHandle, hasResizeHandle } from 'ember-headless-table/plugins/column-resizing';
 import { ColumnVisibility } from 'ember-headless-table/plugins/column-visibility';
 import { ColumnReordering, moveLeft, moveRight } from 'ember-headless-table/plugins/column-reordering';
 import { createHelpers, requestAnimationFrameSettled } from 'ember-headless-table/test-support';
@@ -141,8 +141,6 @@ module('Plugins | resizing', function (hooks) {
   </template>;
 
   class TestComponentA extends Component<{ ctx: Context }> {
-    resizeHandle = resizeHandle;
-
     get table() {
       return this.args.ctx.table;
     }
@@ -166,7 +164,9 @@ module('Plugins | resizing', function (hooks) {
                   <th {{this.modifiers.columnHeader column}}>
                     <span>{{column.name}}</span>
 
-                    <div data-handle {{this.resizeHandle column}}>|</div>
+                    {{#if (hasResizeHandle column)}}
+                      <div data-handle {{resizeHandle column}}>|</div>
+                    {{/if}}
                   </th>
                 {{/each}}
               </tr>


### PR DESCRIPTION
as a consumer (rather than a plugin author), interacting with `meta` is cumbersome.
These additions add convenience for some of the commonly needed data provided by plugins

docs: https://2c80e8fd.ember-headless-table.pages.dev/api/functions/plugins_column_resizing_helpers.hasResizeHandle