### PR TITLE
Add metadata plugin for storing arbitrary information about columns and the table

### DIFF
--- a/.changeset/five-impalas-flow.md
+++ b/.changeset/five-impalas-flow.md
@@ -1,0 +1,71 @@
+---
+'ember-headless-table': minor
+---
+
+New _Metadata_ plugin, for allowing arbitrary data to be stored for each column as well as the whole table.
+This can be useful eliminating prop-drilling in a UI Table implementation consuming the
+headlessTable.
+
+For example, setting up the table can be done like:
+
+```js
+import { headlessTable } from 'ember-headless-table';
+
+class Example {
+  /* ... */
+
+  table = headlessTable(this, {
+    columns: () => [
+      { name: 'A', key: 'A' },
+      {
+        name: 'B',
+        key: 'B',
+        pluginOptions: [
+          Metadata.forColumn(() => ({
+            isBulkSelectable: false,
+          })),
+        ],
+      },
+      {
+        name: 'D',
+        key: 'D',
+        pluginOptions: [Metadata.forColumn(() => ({ isRad: this.dRed }))],
+      },
+    ],
+    data: () => DATA,
+    plugins: [
+      Metadata.with(() => ({
+        onBulkSelectionChange: (...args) => this.doSomething(...args),
+      })),
+    ],
+  });
+}
+```
+
+To allow "bulk selection" behaviors to be integrated into how the Table is rendered --
+which for fancier tables, my span multiple components.
+
+For example: rows may be their own component
+
+```gjs
+// Two helpers are provided for accessing your Metadata
+import { forColumn /*, forTable */ } from 'ember-headless-table/plugins/metadata';
+
+const isBulkSelectable = (column) => forColumn(column, 'isBulkSelectable');
+
+export const Row = <template>
+  <tr>
+    {{#each @table.columns as |column|}}
+      {{#if (isBulkSelectable column)}}
+
+        ... render some checkbox UI ...
+
+      {{else}}
+        <td>
+          {{column.getValueForRow @datum}}
+        </td>
+      {{/if}}
+    {{/each}}
+  </tr>
+</template>;
+```

--- a/docs/plugins/metadata/demo/demo-a.md
+++ b/docs/plugins/metadata/demo/demo-a.md
@@ -1,0 +1,74 @@
+```hbs template
+<div class="h-full overflow-auto" {{this.table.modifiers.container}}>
+  <table>
+   <caption>{{ (this.caption) }}</caption>
+    <thead>
+      <tr>
+        {{#each this.table.columns as |column|}}
+          <th>
+            {{column.name}}
+          </th>
+        {{/each}}
+      </tr>
+    </thead>
+    <tbody>
+      {{#each this.table.rows as |row|}}
+        <tr>
+          {{#each this.table.columns as |column|}}
+            {{#if (this.isBold column)}}
+              <td class="font-bold">
+                This is a bold column.
+              </td>
+            {{else}}
+              <td>
+                {{column.getValueForRow row}}
+              </td>
+            {{/if}}
+          {{/each}}
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+</div>
+```
+```js component
+import Component from '@glimmer/component';
+
+import { headlessTable } from 'ember-headless-table';
+import { Metadata, forColumn, forTable } from 'ember-headless-table/plugins/metadata';
+
+import { DATA } from 'docs-app/sample-data';
+
+export default class extends Component {
+  table = headlessTable(this, {
+    columns: () => [
+      { name: 'column A', key: 'A' },
+      { name: 'column B', key: 'B',
+        pluginOptions: [Metadata.forColumn(() => ({ bold: true }))]
+      },
+      { name: 'column C', key: 'C' },
+    ],
+    data: () => DATA,
+    plugins: [
+      Metadata.with(() => ({
+        title: 'This is a table with custom metadata',
+      }))
+    ],
+  });
+
+  /**
+   * Plugin Integration - all of this can be removed in strict mode, gjs/gts
+   *
+   * This syntax looks weird, but it's read as:
+   *   [property on this component] = [variable in scope]
+   */
+  forColumn = forColumn;
+  forTable = forTable;
+
+  /**
+   * these functions would normally live in "module space"
+   * when using strict mode.
+   */
+   isBold = (column) => forColumn(column, 'bold');
+   caption = () => forTable(this.table, 'title');
+}

--- a/docs/plugins/metadata/index.md
+++ b/docs/plugins/metadata/index.md
@@ -1,0 +1,92 @@
+# Metadata
+
+API Documentation available [here][api-docs]
+
+[api-docs]: /api/modules/plugins_metadata
+
+## Usage
+
+Allows arbitrary data to be stored for each column as well as the whole table.
+This can be useful eliminating prop-drilling in a UI Table implementation consuming the
+headlessTable.
+
+For example, setting up the table can be done like:
+
+```js
+import { headlessTable } from 'ember-headless-table';
+
+class Example {
+  /* ... */
+
+  table = headlessTable(this, {
+    columns: () => [
+      { name: 'A', key: 'A' },
+      {
+        name: 'B',
+        key: 'B',
+        pluginOptions: [
+          Metadata.forColumn(() => ({
+            isBulkSelectable: false,
+          })),
+        ],
+      },
+      {
+        name: 'D',
+        key: 'D',
+        pluginOptions: [Metadata.forColumn(() => ({ isRad: this.dRed }))],
+      },
+    ],
+    data: () => DATA,
+    plugins: [
+      Metadata.with(() => ({
+        onBulkSelectionChange: (...args) => this.doSomething(...args),
+      })),
+    ],
+  });
+}
+```
+
+To allow "bulk selection" behaviors to be integrated into how the Table is rendered --
+which for fancier tables, my span multiple components.
+
+For example: rows may be their own component
+
+```gjs
+// Two helpers are provided for accessing your Metadata
+import { forColumn /*, forTable */ } from 'ember-headless-table/plugins/metadata';
+
+const isBulkSelectable = (column) => forColumn(column, 'isBulkSelectable');
+
+export const Row = <template>
+  <tr>
+    {{#each @table.columns as |column|}}
+      {{#if (isBulkSelectable column)}}
+
+        ... render some checkbox UI ...
+
+      {{else}}
+        <td>
+          {{column.getValueForRow @datum}}
+        </td>
+      {{/if}}
+    {{/each}}
+  </tr>
+</template>;
+```
+
+### ColumnOptions
+
+Any / user-defined.
+
+
+### TableOptions
+
+Any / user-defined.
+
+### Preferences
+
+None
+
+### Accessibility
+
+Not applicable.

--- a/ember-headless-table/package.json
+++ b/ember-headless-table/package.json
@@ -24,6 +24,7 @@
     "./plugins/column-visibility": "./dist/plugins/column-visibility/index.js",
     "./plugins/sticky-columns": "./dist/plugins/sticky-columns/index.js",
     "./plugins/row-selection": "./dist/plugins/row-selection/index.js",
+    "./plugins/metadata": "./dist/plugins/metadata/index.js",
     "./test-support": "./dist/test-support/index.js",
     "./addon-main.js": "./addon-main.js"
   },
@@ -49,6 +50,9 @@
       ],
       "plugins/row-selection": [
         "./dist/plugins/row-selection/index.d.ts"
+      ],
+      "plugins/metadata": [
+        "./dist/plugins/metadata/index.d.ts"
       ],
       "test-support": [
         "./dist/test-support/index.d.ts"

--- a/ember-headless-table/src/plugins/metadata/helpers.ts
+++ b/ember-headless-table/src/plugins/metadata/helpers.ts
@@ -1,0 +1,12 @@
+import { options } from '../-private/base';
+import { Metadata } from './plugin';
+
+import type { Column, Table } from '[public-types]';
+
+export const forColumn = (column: Column<any>, key: string) => {
+  return options.forColumn(column, Metadata)[key];
+};
+
+export const forTable = (table: Table<any>, key: string) => {
+  return options.forTable(table, Metadata)[key];
+};

--- a/ember-headless-table/src/plugins/metadata/index.ts
+++ b/ember-headless-table/src/plugins/metadata/index.ts
@@ -1,0 +1,7 @@
+// Public API
+export * from './helpers';
+export { Metadata } from './plugin';
+export { Metadata as Plugin } from './plugin';
+
+// Public types
+export type { Signature } from './plugin';

--- a/ember-headless-table/src/plugins/metadata/plugin.ts
+++ b/ember-headless-table/src/plugins/metadata/plugin.ts
@@ -1,0 +1,26 @@
+import { BasePlugin } from '../-private/base';
+
+/**
+ * Data stored per column or table can be arbitrary
+ *
+ */
+type ArbitraryData = Record<string, any>;
+
+export interface Signature<Data = ArbitraryData> {
+  Options: {
+    Column: Data;
+    Plugin: Data;
+  };
+}
+
+/**
+ * This plugin does noting,
+ * but gives consumer of it a safe way to store and associate "any" data with columns
+ * (and have a generic top-level bucket of data as well)
+ *
+ * This "metadata" stored per column per table is managed via the "options" part of the Signature, as
+ * "meta" is a term used for plugins for plugin authors.
+ */
+export class Metadata<S extends Signature> extends BasePlugin<S> {
+  name = 'metadata';
+}

--- a/test-app/tests/plugins/metadata/rendering-test.gts
+++ b/test-app/tests/plugins/metadata/rendering-test.gts
@@ -1,0 +1,143 @@
+import { tracked } from '@glimmer/tracking';
+import { find, settled, render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+
+import { headlessTable } from 'ember-headless-table';
+import { Metadata, forColumn, forTable } from 'ember-headless-table/plugins/metadata';
+
+import { setOwner } from '@ember/application';
+import { DATA } from 'test-app/data';
+
+module('Plugins | metadata', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('Reactivity', function (hooks) {
+    class Context {
+      @tracked bRad = 'true';
+      @tracked bIsDoingOneHandledFlips = 'true';
+      @tracked dRed = false;
+
+      @tracked tableFoo = '2';
+
+      table = headlessTable(this, {
+        columns: () => [
+          { name: 'A', key: 'A' },
+          { name: 'B', key: 'B', pluginOptions: [
+            Metadata.forColumn(() => ({
+              isRad: this.bRad,
+              doingOneHandedFlips: this.bIsDoingOneHandledFlips
+            }))
+          ] },
+          { name: 'D', key: 'D', pluginOptions: [Metadata.forColumn(() => ({ isRad: this.dRed }))] },
+        ],
+        data: () => DATA,
+        plugins: [Metadata.with(() => ({ foo: this.tableFoo }))],
+      });
+    }
+
+    let ctx: Context;
+
+    hooks.beforeEach(async function (assert) {
+      ctx = new Context();
+      setOwner(ctx, this.owner);
+
+      let step = (key: string, eventName: string, passthrough: string) => {
+        assert.step(`${key}@${eventName}: ${passthrough}`);
+        return passthrough;
+      }
+
+      await render(
+        <template>
+          {{#each ctx.table.columns as |column|}}
+            <span class="{{column.key}}">
+              <span class="isRad">{{step column.key "isRad" (forColumn column "isRad")}}</span>
+              <span class="isMissing">{{step column.key "isMissing" (forColumn column "isMissing")}}</span>
+              <span class="doingOneHandedFlips">{{step column.key "flips" (forColumn column "doingOneHandedFlips")}}</span>
+            </span>
+          {{/each}}
+
+          <span class="table">
+            <span class="foo">{{step "table" "foo" (forTable ctx.table "foo")}}</span>
+            <span class="bar">{{step "table" "bar" (forTable ctx.table "bar")}}</span>
+          </span>
+        </template>
+      );
+
+      assert.verifySteps([
+        "A@isRad: undefined",
+        "A@isMissing: undefined",
+        "A@flips: undefined",
+        "B@isRad: true",
+        "B@isMissing: undefined",
+        "B@flips: true",
+        "D@isRad: false",
+        "D@isMissing: undefined",
+        "D@flips: undefined",
+        "table@foo: 2",
+        "table@bar: undefined"
+      ]);
+    });
+
+    test('it works, statically', async function (assert) {
+      assert.dom(find('.A .isRad')).hasNoText()
+      assert.dom(find('.A .isMissing')).hasNoText()
+      assert.dom(find('.A .doingOneHandedFlips')).hasNoText()
+      assert.dom(find('.B .isRad')).hasText('true')
+      assert.dom(find('.B .isMissing')).hasNoText()
+      assert.dom(find('.B .doingOneHandedFlips')).hasText('true')
+      assert.dom(find('.D .isRad')).hasText('false')
+      assert.dom(find('.D .isMissing')).hasNoText()
+      assert.dom(find('.D .doingOneHandedFlips')).hasNoText()
+
+      assert.dom(find('.table .foo')).hasText('2');
+      assert.dom(find('.table .bar')).hasNoText();
+
+      assert.verifySteps([]);
+    });
+
+    test('it works, dynamically', async function (assert) {
+      ctx.bRad = 'false';
+      await settled();
+
+      assert.dom(find('.B .isRad')).hasText('false');
+      assert.dom(find('.B .doingOneHandedFlips')).hasText('true');
+      assert.dom(find('.table .foo')).hasText('2');
+      assert.verifySteps([
+        "B@isRad: false",
+        "B@isMissing: undefined",
+        "B@flips: true"
+      ],
+        `all of column B's properties are re-evaluated, because this test does not do finer-grained reactivity. `
+         + `but that is possible, if the user wishes`);
+
+      ctx.bIsDoingOneHandledFlips = 'false';
+      await settled();
+
+      assert.dom(find('.B .isRad')).hasText('false');
+      assert.dom(find('.B .doingOneHandedFlips')).hasText('false');
+      assert.dom(find('.table .foo')).hasText('2');
+      assert.verifySteps([
+        "B@isRad: false",
+        "B@isMissing: undefined",
+        "B@flips: false"
+      ],
+        `all of column B's properties are re-evaluated, because this test does not do finer-grained reactivity. `
+         + `but that is possible, if the user wishes`);
+
+      ctx.tableFoo = '3';
+      await settled();
+
+      assert.dom(find('.B .isRad')).hasText('false');
+      assert.dom(find('.B .doingOneHandedFlips')).hasText('false');
+      assert.dom(find('.table .foo')).hasText('3');
+      assert.verifySteps([
+        "table@foo: 3",
+        "table@bar: undefined"
+      ],
+        `all of column B's properties are re-evaluated, because this test does not do finer-grained reactivity. `
+         + `but that is possible, if the user wishes`);
+    });
+  });
+
+});


### PR DESCRIPTION
Why add this? See the changelog entry: https://github.com/CrowdStrike/ember-headless-table/pull/58/files#diff-cf61d7d4315ac16e892cfafcf5ab3fbf01c92148dc9da54de580eeb11cd8e77b

tl;dr: for consumer's organizational purposes, it'll be easier to have "arbitrary data" tied to each column and the table itself to help thread tied-to-column or tied-to-table data through multiple layers of components without having to resort to prop drilling.

_The matadata plugin could be used like a service, but scoped to "per table instance"_


We can preview the changelog entry here, once merged: https://github.com/CrowdStrike/ember-headless-table/pull/64
