### PR TITLE
Demonstrate pre ordering columns

### DIFF
--- a/.changeset/five-impalas-flow.md
+++ b/.changeset/five-impalas-flow.md
@@ -1,0 +1,71 @@
+---
+'ember-headless-table': minor
+---
+
+New _Metadata_ plugin, for allowing arbitrary data to be stored for each column as well as the whole table.
+This can be useful eliminating prop-drilling in a UI Table implementation consuming the
+headlessTable.
+
+For example, setting up the table can be done like:
+
+```js
+import { headlessTable } from 'ember-headless-table';
+
+class Example {
+  /* ... */
+
+  table = headlessTable(this, {
+    columns: () => [
+      { name: 'A', key: 'A' },
+      {
+        name: 'B',
+        key: 'B',
+        pluginOptions: [
+          Metadata.forColumn(() => ({
+            isBulkSelectable: false,
+          })),
+        ],
+      },
+      {
+        name: 'D',
+        key: 'D',
+        pluginOptions: [Metadata.forColumn(() => ({ isRad: this.dRed }))],
+      },
+    ],
+    data: () => DATA,
+    plugins: [
+      Metadata.with(() => ({
+        onBulkSelectionChange: (...args) => this.doSomething(...args),
+      })),
+    ],
+  });
+}
+```
+
+To allow "bulk selection" behaviors to be integrated into how the Table is rendered --
+which for fancier tables, my span multiple components.
+
+For example: rows may be their own component
+
+```gjs
+// Two helpers are provided for accessing your Metadata
+import { forColumn /*, forTable */ } from 'ember-headless-table/plugins/metadata';
+
+const isBulkSelectable = (column) => forColumn(column, 'isBulkSelectable');
+
+export const Row = <template>
+  <tr>
+    {{#each @table.columns as |column|}}
+      {{#if (isBulkSelectable column)}}
+
+        ... render some checkbox UI ...
+
+      {{else}}
+        <td>
+          {{column.getValueForRow @datum}}
+        </td>
+      {{/if}}
+    {{/each}}
+  </tr>
+</template>;
+```

--- a/.changeset/stale-plants-care.md
+++ b/.changeset/stale-plants-care.md
@@ -1,0 +1,59 @@
+---
+'ember-headless-table': minor
+---
+
+Add a new API for the column-reordering plugin that allows for
+managing column order independently of the table's column order,
+for example, in a configuration UI / preview, one may want to
+see how their changes will look before applying them to the table.
+
+To use this new API, there are two relevant imports:
+
+```js
+import {
+  ColumnOrder,
+  setColumnOrder,
+} from 'ember-headless-table/plugins/column-reordering';
+```
+
+To manage the "preview column order",
+you'll want to instantiate the `ColumnOrder` class,
+and then once your changes are done, call `setColumnOrder` and pass
+both the table and the `ColumnOrder` instance:
+
+```js
+class Demo {
+  @tracked pendingColumnOrder;
+
+  changeColumnOrder = () => {
+    this.pendingColumnOrder = new ColumnOrder({
+      columns: () => this.columns,
+    });
+  };
+
+  handleReconfigure = () => {
+    setColumnOrder(this.table, this.pendingColumnOrder);
+    this.pendingColumnOrder = null;
+  };
+}
+```
+
+In this example, when working with `this.pendingColumnOrder`, you may use
+familiar "moveLeft" and "moveRight" behaviors,
+
+```hbs
+{{#let this.pendingColumnOrder as |order|}}
+
+  {{#each order.orderedColumns as |column|}}
+
+    <button {{on 'click' (fn order.moveLeft column.key)}}> ⇦ </button>
+
+    {{column.name}}
+
+    <button {{on 'click' (fn order.moveRight column.key)}}> ⇨ </button>
+
+  {{/each}}
+
+  <button {{on 'click' this.handleReconfigure}}>Submit changes</button>
+{{/let}}
+```

--- a/docs/demos/external-column-ordering/demo/demo-a.md
+++ b/docs/demos/external-column-ordering/demo/demo-a.md
@@ -1,0 +1,93 @@
+```hbs template
+{{#if this.pendingColumnOrder}}
+  <div class="grid gap-4">
+    {{#let this.pendingColumnOrder as |order|}}
+
+      <div class="grid gap-4 grid-flow-col">
+        {{#each order.orderedColumns as |column|}}
+          <div class="flex gap-2">
+            <button {{on 'click' (fn order.moveLeft column.key)}}> ⇦ </button>
+            {{column.name}}
+            <button {{on 'click' (fn order.moveRight column.key)}}> ⇨ </button>
+          </div>
+        {{/each}}
+      </div>
+
+      <button {{on 'click' this.handleReconfigure}}>Submit changes</button>
+    {{/let}}
+  </div>
+{{else}}
+  <button {{on 'click' this.changeColumnOrder}}>
+    Configure columns
+  </button>
+{{/if}}
+
+<hr />
+
+
+The order of the columns in the table
+(table not rendered for focusing on the configuration)
+
+<pre>
+  {{#each this.columns as |column|}}
+    {{column.name}}
+  {{/each}}
+</pre>
+```
+```js component
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import { headlessTable } from 'ember-headless-table';
+import { meta, columns } from 'ember-headless-table/plugins';
+import {
+  ColumnReordering,
+  ColumnOrder,
+  setColumnOrder,
+  moveLeft, moveRight
+} from 'ember-headless-table/plugins/column-reordering';
+
+import { DATA } from 'docs-app/sample-data';
+
+export default class extends Component {
+  @tracked pendingColumnOrder;
+
+  changeColumnOrder = () => {
+    this.pendingColumnOrder = new ColumnOrder({
+      columns: () => this.columns,
+    });
+  }
+
+  handleReconfigure = () => {
+    setColumnOrder(this.table, this.pendingColumnOrder);
+    this.pendingColumnOrder = null;
+  }
+
+
+  /**
+   * Generic table code below
+   */
+
+  table = headlessTable(this, {
+    columns: () => [
+      { name: 'column A', key: 'A' },
+      { name: 'column B', key: 'B' },
+      { name: 'column C', key: 'C' },
+    ],
+    data: () => DATA,
+    plugins: [ColumnReordering],
+  });
+
+  get columns() {
+    return columns.for(this.table);
+  }
+
+  /**
+   * Plugin Integration - all of this can be removed in strict mode, gjs/gts
+   *
+   * This syntax looks weird, but it's read as:
+   *   [property on this component] = [variable in scope]
+   */
+  moveLeft = moveLeft;
+  moveRight = moveRight;
+}

--- a/docs/demos/external-column-ordering/index.md
+++ b/docs/demos/external-column-ordering/index.md
@@ -1,0 +1,6 @@
+# External column (re)ordering
+
+This demo shows how to set the order of columns before _comitting_ those changes to the actual table.
+This pattern could be used for configuration UIs where a person interacting with the table may want to configure and save their configuration before applying changes.
+
+

--- a/docs/demos/external-column-ordering/index.md
+++ b/docs/demos/external-column-ordering/index.md
@@ -1,6 +1,6 @@
 # External column (re)ordering
 
-This demo shows how to set the order of columns before _comitting_ those changes to the actual table.
+This demo shows how to set the order of columns before _committing_ those changes to the actual table.
 This pattern could be used for configuration UIs where a person interacting with the table may want to configure and save their configuration before applying changes.
 
 

--- a/docs/plugins/metadata/demo/demo-a.md
+++ b/docs/plugins/metadata/demo/demo-a.md
@@ -1,0 +1,74 @@
+```hbs template
+<div class="h-full overflow-auto" {{this.table.modifiers.container}}>
+  <table>
+   <caption>{{ (this.caption) }}</caption>
+    <thead>
+      <tr>
+        {{#each this.table.columns as |column|}}
+          <th>
+            {{column.name}}
+          </th>
+        {{/each}}
+      </tr>
+    </thead>
+    <tbody>
+      {{#each this.table.rows as |row|}}
+        <tr>
+          {{#each this.table.columns as |column|}}
+            {{#if (this.isBold column)}}
+              <td class="font-bold">
+                This is a bold column.
+              </td>
+            {{else}}
+              <td>
+                {{column.getValueForRow row}}
+              </td>
+            {{/if}}
+          {{/each}}
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+</div>
+```
+```js component
+import Component from '@glimmer/component';
+
+import { headlessTable } from 'ember-headless-table';
+import { Metadata, forColumn, forTable } from 'ember-headless-table/plugins/metadata';
+
+import { DATA } from 'docs-app/sample-data';
+
+export default class extends Component {
+  table = headlessTable(this, {
+    columns: () => [
+      { name: 'column A', key: 'A' },
+      { name: 'column B', key: 'B',
+        pluginOptions: [Metadata.forColumn(() => ({ bold: true }))]
+      },
+      { name: 'column C', key: 'C' },
+    ],
+    data: () => DATA,
+    plugins: [
+      Metadata.with(() => ({
+        title: 'This is a table with custom metadata',
+      }))
+    ],
+  });
+
+  /**
+   * Plugin Integration - all of this can be removed in strict mode, gjs/gts
+   *
+   * This syntax looks weird, but it's read as:
+   *   [property on this component] = [variable in scope]
+   */
+  forColumn = forColumn;
+  forTable = forTable;
+
+  /**
+   * these functions would normally live in "module space"
+   * when using strict mode.
+   */
+   isBold = (column) => forColumn(column, 'bold');
+   caption = () => forTable(this.table, 'title');
+}

--- a/docs/plugins/metadata/index.md
+++ b/docs/plugins/metadata/index.md
@@ -1,0 +1,92 @@
+# Metadata
+
+API Documentation available [here][api-docs]
+
+[api-docs]: /api/modules/plugins_metadata
+
+## Usage
+
+Allows arbitrary data to be stored for each column as well as the whole table.
+This can be useful eliminating prop-drilling in a UI Table implementation consuming the
+headlessTable.
+
+For example, setting up the table can be done like:
+
+```js
+import { headlessTable } from 'ember-headless-table';
+
+class Example {
+  /* ... */
+
+  table = headlessTable(this, {
+    columns: () => [
+      { name: 'A', key: 'A' },
+      {
+        name: 'B',
+        key: 'B',
+        pluginOptions: [
+          Metadata.forColumn(() => ({
+            isBulkSelectable: false,
+          })),
+        ],
+      },
+      {
+        name: 'D',
+        key: 'D',
+        pluginOptions: [Metadata.forColumn(() => ({ isRad: this.dRed }))],
+      },
+    ],
+    data: () => DATA,
+    plugins: [
+      Metadata.with(() => ({
+        onBulkSelectionChange: (...args) => this.doSomething(...args),
+      })),
+    ],
+  });
+}
+```
+
+To allow "bulk selection" behaviors to be integrated into how the Table is rendered --
+which for fancier tables, my span multiple components.
+
+For example: rows may be their own component
+
+```gjs
+// Two helpers are provided for accessing your Metadata
+import { forColumn /*, forTable */ } from 'ember-headless-table/plugins/metadata';
+
+const isBulkSelectable = (column) => forColumn(column, 'isBulkSelectable');
+
+export const Row = <template>
+  <tr>
+    {{#each @table.columns as |column|}}
+      {{#if (isBulkSelectable column)}}
+
+        ... render some checkbox UI ...
+
+      {{else}}
+        <td>
+          {{column.getValueForRow @datum}}
+        </td>
+      {{/if}}
+    {{/each}}
+  </tr>
+</template>;
+```
+
+### ColumnOptions
+
+Any / user-defined.
+
+
+### TableOptions
+
+Any / user-defined.
+
+### Preferences
+
+None
+
+### Accessibility
+
+Not applicable.

--- a/ember-headless-table/package.json
+++ b/ember-headless-table/package.json
@@ -24,6 +24,7 @@
     "./plugins/column-visibility": "./dist/plugins/column-visibility/index.js",
     "./plugins/sticky-columns": "./dist/plugins/sticky-columns/index.js",
     "./plugins/row-selection": "./dist/plugins/row-selection/index.js",
+    "./plugins/metadata": "./dist/plugins/metadata/index.js",
     "./test-support": "./dist/test-support/index.js",
     "./addon-main.js": "./addon-main.js"
   },
@@ -49,6 +50,9 @@
       ],
       "plugins/row-selection": [
         "./dist/plugins/row-selection/index.d.ts"
+      ],
+      "plugins/metadata": [
+        "./dist/plugins/metadata/index.d.ts"
       ],
       "test-support": [
         "./dist/test-support/index.d.ts"

--- a/ember-headless-table/src/plugins/column-reordering/helpers.ts
+++ b/ember-headless-table/src/plugins/column-reordering/helpers.ts
@@ -1,7 +1,8 @@
 import { meta } from '../-private/base';
 import { ColumnReordering } from './plugin';
 
-import type { Column } from '[public-types]';
+import type { ColumnOrder } from './plugin';
+import type { Column, Table } from '[public-types]';
 
 /**
  * Move the column one position to the left.
@@ -14,6 +15,13 @@ export const moveLeft = (column: Column) => meta.forColumn(column, ColumnReorder
  * If the column is last, nothing will happen.
  */
 export const moveRight = (column: Column) => meta.forColumn(column, ColumnReordering).moveRight();
+
+/**
+ * Override all column positions at once.
+ */
+export const setColumnOrder = (table: Table, order: ColumnOrder) => {
+  return meta.forTable(table, ColumnReordering).setOrder(order);
+};
 
 /**
  * Ask if the column cannot move to the left

--- a/ember-headless-table/src/plugins/column-reordering/plugin.ts
+++ b/ember-headless-table/src/plugins/column-reordering/plugin.ts
@@ -114,16 +114,25 @@ export class TableMeta {
     existingOrder: this.read(),
   });
 
+  /**
+   * Get the curret order/position of a column
+   */
   @action
   getPosition(column: Column) {
     return this.columnOrder.get(column.key);
   }
 
+  /**
+   * Swap the column with the column at `newPosition`
+   */
   @action
   setPosition(column: Column, newPosition: number) {
     return this.columnOrder.swapWith(column.key, newPosition);
   }
 
+  /**
+   * Using a `ColumnOrder` instance, set the order of all columns
+   */
   setOrder = (order: ColumnOrder) => {
     this.columnOrder.setAll(order.map);
   };

--- a/ember-headless-table/src/plugins/column-reordering/plugin.ts
+++ b/ember-headless-table/src/plugins/column-reordering/plugin.ts
@@ -124,6 +124,10 @@ export class TableMeta {
     return this.columnOrder.swapWith(column.key, newPosition);
   }
 
+  setOrder = (order: ColumnOrder) => {
+    this.columnOrder.setAll(order.map);
+  };
+
   /**
    * Revert to default config, delete preferences,
    * and clear the columnOrder
@@ -189,7 +193,7 @@ export class ColumnOrder {
   constructor(
     private args: {
       columns: () => Column[];
-      save: (order: Map<string, number>) => void;
+      save?: (order: Map<string, number>) => void;
       existingOrder?: Map<string, number>;
     }
   ) {
@@ -230,6 +234,14 @@ export class ColumnOrder {
 
     this.swapWith(key, nextPosition);
   }
+
+  setAll = (map: Map<string, number>) => {
+    this.map.clear();
+
+    for (let [key, value] of map.entries()) {
+      this.map.set(key, value);
+    }
+  };
 
   /**
    * To account for columnVisibilty, we need to:
@@ -334,7 +346,7 @@ export class ColumnOrder {
       this.map.set(key, position);
     }
 
-    this.args.save(this.map);
+    this.args.save?.(this.map);
   }
 
   @action
@@ -356,17 +368,6 @@ export class ColumnOrder {
   @cached
   get orderedMap(): ReadonlyMap<string, number> {
     return orderOf(this.args.columns(), this.map);
-  }
-
-  /**
-   * When columns are removed or hidden, our positions don't change
-   * but when doing the math, we want to adjust things based on 0-indexed counting
-   *
-   * TODO: figure out if we need this??
-   */
-  @cached
-  get adjustedColumns(): Column[] {
-    return [];
   }
 
   @cached

--- a/ember-headless-table/src/plugins/metadata/helpers.ts
+++ b/ember-headless-table/src/plugins/metadata/helpers.ts
@@ -1,0 +1,12 @@
+import { options } from '../-private/base';
+import { Metadata } from './plugin';
+
+import type { Column, Table } from '[public-types]';
+
+export const forColumn = (column: Column<any>, key: string) => {
+  return options.forColumn(column, Metadata)[key];
+};
+
+export const forTable = (table: Table<any>, key: string) => {
+  return options.forTable(table, Metadata)[key];
+};

--- a/ember-headless-table/src/plugins/metadata/index.ts
+++ b/ember-headless-table/src/plugins/metadata/index.ts
@@ -1,0 +1,7 @@
+// Public API
+export * from './helpers';
+export { Metadata } from './plugin';
+export { Metadata as Plugin } from './plugin';
+
+// Public types
+export type { Signature } from './plugin';

--- a/ember-headless-table/src/plugins/metadata/plugin.ts
+++ b/ember-headless-table/src/plugins/metadata/plugin.ts
@@ -1,0 +1,26 @@
+import { BasePlugin } from '../-private/base';
+
+/**
+ * Data stored per column or table can be arbitrary
+ *
+ */
+type ArbitraryData = Record<string, any>;
+
+export interface Signature<Data = ArbitraryData> {
+  Options: {
+    Column: Data;
+    Plugin: Data;
+  };
+}
+
+/**
+ * This plugin does noting,
+ * but gives consumer of it a safe way to store and associate "any" data with columns
+ * (and have a generic top-level bucket of data as well)
+ *
+ * This "metadata" stored per column per table is managed via the "options" part of the Signature, as
+ * "meta" is a term used for plugins for plugin authors.
+ */
+export class Metadata<S extends Signature> extends BasePlugin<S> {
+  name = 'metadata';
+}

--- a/test-app/tests/plugins/column-reordering/ColumnOrder-test.ts
+++ b/test-app/tests/plugins/column-reordering/ColumnOrder-test.ts
@@ -7,12 +7,73 @@ import type { Column } from 'ember-headless-table';
 module('Plugin | column-reordering | ColumnOrder', function () {
   const toEntries = (map: ReadonlyMap<unknown, unknown>) => [...map.entries()];
 
+  module('#setAll', function (hooks) {
+    let order: ColumnOrder;
+
+    hooks.beforeEach(function (assert) {
+      order = new ColumnOrder({
+        columns: () =>
+          [
+            { key: 'A' },
+            { key: 'B' },
+            { key: 'C' },
+            { key: 'D' },
+            { key: 'E' },
+            { key: 'F' },
+            /**
+             * This cast is a lie, but a useful one, as these #set
+             * tests don't actually care about the Column structure
+             * of this data -- only that a key exists
+             */
+          ] as Column[],
+      });
+
+      assert.deepEqual(
+        toEntries(order.orderedMap),
+        [
+          ['A', 0],
+          ['B', 1],
+          ['C', 2],
+          ['D', 3],
+          ['E', 4],
+          ['F', 5],
+        ],
+        'test is set up'
+      );
+    });
+
+    test('can change the order of all columns at once', function (assert) {
+      let newOrder = new Map<string, number>([
+        ['E', 5],
+        ['C', 1],
+        ['F', 0],
+        ['B', 3],
+        ['D', 2],
+        ['A', 4],
+      ]);
+
+      order.setAll(newOrder);
+
+      assert.deepEqual(
+        toEntries(order.orderedMap),
+        [
+          ['F', 0],
+          ['C', 1],
+          ['D', 2],
+          ['B', 3],
+          ['A', 4],
+          ['E', 5],
+        ],
+        'columns are in the correct order'
+      );
+    });
+  });
+
   module('#moveRight', function (hooks) {
     let order: ColumnOrder;
 
     hooks.beforeEach(function (assert) {
       order = new ColumnOrder({
-        save: () => {},
         columns: () =>
           [
             { key: 'A' },

--- a/test-app/tests/plugins/metadata/rendering-test.gts
+++ b/test-app/tests/plugins/metadata/rendering-test.gts
@@ -1,0 +1,143 @@
+import { tracked } from '@glimmer/tracking';
+import { find, settled, render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+
+import { headlessTable } from 'ember-headless-table';
+import { Metadata, forColumn, forTable } from 'ember-headless-table/plugins/metadata';
+
+import { setOwner } from '@ember/application';
+import { DATA } from 'test-app/data';
+
+module('Plugins | metadata', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('Reactivity', function (hooks) {
+    class Context {
+      @tracked bRad = 'true';
+      @tracked bIsDoingOneHandledFlips = 'true';
+      @tracked dRed = false;
+
+      @tracked tableFoo = '2';
+
+      table = headlessTable(this, {
+        columns: () => [
+          { name: 'A', key: 'A' },
+          { name: 'B', key: 'B', pluginOptions: [
+            Metadata.forColumn(() => ({
+              isRad: this.bRad,
+              doingOneHandedFlips: this.bIsDoingOneHandledFlips
+            }))
+          ] },
+          { name: 'D', key: 'D', pluginOptions: [Metadata.forColumn(() => ({ isRad: this.dRed }))] },
+        ],
+        data: () => DATA,
+        plugins: [Metadata.with(() => ({ foo: this.tableFoo }))],
+      });
+    }
+
+    let ctx: Context;
+
+    hooks.beforeEach(async function (assert) {
+      ctx = new Context();
+      setOwner(ctx, this.owner);
+
+      let step = (key: string, eventName: string, passthrough: string) => {
+        assert.step(`${key}@${eventName}: ${passthrough}`);
+        return passthrough;
+      }
+
+      await render(
+        <template>
+          {{#each ctx.table.columns as |column|}}
+            <span class="{{column.key}}">
+              <span class="isRad">{{step column.key "isRad" (forColumn column "isRad")}}</span>
+              <span class="isMissing">{{step column.key "isMissing" (forColumn column "isMissing")}}</span>
+              <span class="doingOneHandedFlips">{{step column.key "flips" (forColumn column "doingOneHandedFlips")}}</span>
+            </span>
+          {{/each}}
+
+          <span class="table">
+            <span class="foo">{{step "table" "foo" (forTable ctx.table "foo")}}</span>
+            <span class="bar">{{step "table" "bar" (forTable ctx.table "bar")}}</span>
+          </span>
+        </template>
+      );
+
+      assert.verifySteps([
+        "A@isRad: undefined",
+        "A@isMissing: undefined",
+        "A@flips: undefined",
+        "B@isRad: true",
+        "B@isMissing: undefined",
+        "B@flips: true",
+        "D@isRad: false",
+        "D@isMissing: undefined",
+        "D@flips: undefined",
+        "table@foo: 2",
+        "table@bar: undefined"
+      ]);
+    });
+
+    test('it works, statically', async function (assert) {
+      assert.dom(find('.A .isRad')).hasNoText()
+      assert.dom(find('.A .isMissing')).hasNoText()
+      assert.dom(find('.A .doingOneHandedFlips')).hasNoText()
+      assert.dom(find('.B .isRad')).hasText('true')
+      assert.dom(find('.B .isMissing')).hasNoText()
+      assert.dom(find('.B .doingOneHandedFlips')).hasText('true')
+      assert.dom(find('.D .isRad')).hasText('false')
+      assert.dom(find('.D .isMissing')).hasNoText()
+      assert.dom(find('.D .doingOneHandedFlips')).hasNoText()
+
+      assert.dom(find('.table .foo')).hasText('2');
+      assert.dom(find('.table .bar')).hasNoText();
+
+      assert.verifySteps([]);
+    });
+
+    test('it works, dynamically', async function (assert) {
+      ctx.bRad = 'false';
+      await settled();
+
+      assert.dom(find('.B .isRad')).hasText('false');
+      assert.dom(find('.B .doingOneHandedFlips')).hasText('true');
+      assert.dom(find('.table .foo')).hasText('2');
+      assert.verifySteps([
+        "B@isRad: false",
+        "B@isMissing: undefined",
+        "B@flips: true"
+      ],
+        `all of column B's properties are re-evaluated, because this test does not do finer-grained reactivity. `
+         + `but that is possible, if the user wishes`);
+
+      ctx.bIsDoingOneHandledFlips = 'false';
+      await settled();
+
+      assert.dom(find('.B .isRad')).hasText('false');
+      assert.dom(find('.B .doingOneHandedFlips')).hasText('false');
+      assert.dom(find('.table .foo')).hasText('2');
+      assert.verifySteps([
+        "B@isRad: false",
+        "B@isMissing: undefined",
+        "B@flips: false"
+      ],
+        `all of column B's properties are re-evaluated, because this test does not do finer-grained reactivity. `
+         + `but that is possible, if the user wishes`);
+
+      ctx.tableFoo = '3';
+      await settled();
+
+      assert.dom(find('.B .isRad')).hasText('false');
+      assert.dom(find('.B .doingOneHandedFlips')).hasText('false');
+      assert.dom(find('.table .foo')).hasText('3');
+      assert.verifySteps([
+        "table@foo: 3",
+        "table@bar: undefined"
+      ],
+        `all of column B's properties are re-evaluated, because this test does not do finer-grained reactivity. `
+         + `but that is possible, if the user wishes`);
+    });
+  });
+
+});


### PR DESCRIPTION
Requires that https://github.com/CrowdStrike/ember-headless-table/pull/58/ be merged first.

If reviewing this before #58 is merged, here is the diff between the two branches: https://github.com/CrowdStrike/ember-headless-table/compare/metadata-plugin...demonstrate-pre-ordering-columns