### PR TITLE
chore(docs): add basic table example

### DIFF
--- a/docs/demos/basic-table/demo/demo-a.md
+++ b/docs/demos/basic-table/demo/demo-a.md
@@ -1,0 +1,59 @@
+```hbs template
+<div {{this.table.modifiers.container}}>
+  <table>
+    <thead>
+      <tr>
+        {{#each this.table.columns as |column|}}
+          <th {{this.table.modifiers.columnHeader column}}>
+            {{column.name}}
+          </th>
+        {{/each}}
+      </tr>
+    </thead>
+    <tbody>
+      {{#each this.table.rows as |row|}}
+        <tr>
+          {{#each this.table.columns as |column|}}
+            <td>
+              {{column.getValueForRow row}}
+            </td>
+          {{/each}}
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+</div>
+```
+
+```js component
+import Component from '@glimmer/component';
+
+import { headlessTable } from 'ember-headless-table';
+
+export default class extends Component {
+  table = headlessTable(this, {
+    columns: () => [
+      { name: 'column A', key: 'A' },
+      { name: 'column B', key: 'B' },
+      { name: 'column C', key: 'C' },
+    ],
+    data: () => [
+      {
+        A: 'Apple',
+        B: 'Berry',
+        C: 'Cranberry',
+      },
+      {
+        A: 'Avocado',
+        B: 'Plantain',
+        C: 'Cucumber',
+      },
+      {
+        A: 'A Squash',
+        B: 'Banana',
+        C: 'Corn',
+      },
+    ],
+  });
+}
+```

--- a/docs/demos/basic-table/demo/demo-a.md
+++ b/docs/demos/basic-table/demo/demo-a.md
@@ -4,7 +4,7 @@
     <thead>
       <tr>
         {{#each this.table.columns as |column|}}
-          <th {{this.table.modifiers.columnHeader column}}>
+          <th>
             {{column.name}}
           </th>
         {{/each}}

--- a/docs/demos/basic-table/index.md
+++ b/docs/demos/basic-table/index.md
@@ -1,0 +1,3 @@
+# Basic table
+
+A minimal example of a table.


### PR DESCRIPTION
Hello 👋 

When reading the documentation it wasn't immediately clear which parts are necessary to create a minimal table. The tables under [Styles](https://ember-headless-table.pages.dev/docs/adding-style) are more or less the most basic version, but don't show how data should be passed.

To experiment with this library I've created the following basic table example. It could perhaps be useful to include something like this in the docs?

Awesome work on the library btw!