### PR TITLE
Use style tag for sticky columns instead of modifiers

### DIFF
--- a/.changeset/perfect-experts-buy.md
+++ b/.changeset/perfect-experts-buy.md
@@ -1,0 +1,67 @@
+---
+'ember-headless-table': minor
+---
+
+An alternative, yet more verbose, option is now available for the sticky / pinnable columns plugin.
+
+This is, in part, due to waiting on
+[RFC#883: add new timing capabilities to modifier manager](https://github.com/emberjs/rfcs/pull/883).
+
+But also, as an escape hatch for performance sensitive situations where one would want to avoid altering any style attributes during render (as is one of the primary use cases of RFC#883) as this causes repaint calculations and degraded performance in the browser.
+
+This new technique for the sticky/pinnable colums plugin allows you to set the `style` attribute so that the browser can calculate layout in a single pass.
+
+To opt in to this, two things must be done:
+
+1. invoke the `styleStringFor` helper in the template, and set the result to the `style` attribute for the `th` and `td` cells.
+
+   ```gjs
+   import { styleStringFor } from 'ember-headless-table/plugins/sticky-columns'
+
+   // ...
+
+   <template>
+       <div class="h-full overflow-auto">
+         <table>
+           <thead>
+             <tr class="relative">
+               {{#each @table.columns as |column|}}
+                 <th style="{{styleStringFor column}}">
+                   {{column.name}}
+                 </th>
+               {{/each}}
+             </tr>
+           </thead>
+           <tbody>
+             {{#each @table.rows as |row|}}
+               <tr class="relative">
+                 {{#each @table.columns as |column|}}
+                   <td style="{{styleStringFor column}}">
+                     {{column.getValueForRow row}}
+                   </td>
+                 {{/each}}
+               </tr>
+             {{/each}}
+           </tbody>
+         </table>
+       </div>
+   </template>
+   ```
+
+2. when configuring the `StickyColumns` plugin in `headlessTable`, configure the the `workaroundForModifierTimingUpdateRFC883` flag to `true`. This allows td and th cells to have modifiers without causing repaints due to style changes caused by the sticky columns plugin.
+
+```js
+class Example {
+  table = headlessTable(this, {
+    columns: () => [
+      // ...
+    ],
+    // ...
+    plugins: [
+      StickyColumns.with(() => ({
+        workaroundForModifierTimingUpdateRFC883: true,
+      })),
+    ],
+  });
+}
+```

--- a/.github/actions/download-built-package/action.yml
+++ b/.github/actions/download-built-package/action.yml
@@ -10,4 +10,4 @@ runs:
       path: ${{ env.dist }}
   - name: 'Install dependencies'
     shell: 'bash'
-    run: pnpm install
+    run: pnpm install --force

--- a/docs/plugins/sticky-column/demo/demo-a.md
+++ b/docs/plugins/sticky-column/demo/demo-a.md
@@ -5,8 +5,8 @@
       <tr class="relative">
         {{#each this.table.columns as |column|}}
           <th
-            {{this.table.modifiers.columnHeader column}}
             class="{{if (this.isSticky column) 'bg-basement' 'bg-ground-floor'}}"
+            style="{{this.styleStringFor column}}"
           >
             <span class="name">{{column.name}}</span><br>
           </th>
@@ -18,8 +18,8 @@
         <tr class="relative">
           {{#each this.table.columns as |column|}}
             <td
-              {{this.table.modifiers.columnHeader column}}
               class="{{if (this.isSticky column) 'bg-basement' 'bg-ground-floor'}}"
+              style="{{this.styleStringFor column}}"
             >
               {{column.getValueForRow row}}
             </td>
@@ -34,7 +34,7 @@
 import Component from '@glimmer/component';
 
 import { headlessTable } from 'ember-headless-table';
-import { StickyColumns, isSticky } from 'ember-headless-table/plugins/sticky-columns';
+import { StickyColumns, isSticky, styleStringFor } from 'ember-headless-table/plugins/sticky-columns';
 import { ColumnResizing } from 'ember-headless-table/plugins/column-resizing';
 import { ColumnVisibility } from 'ember-headless-table/plugins/column-visibility';
 
@@ -69,6 +69,7 @@ export default class extends Component {
    *   [property on this component] = [variable in scope]
    */
   isSticky = isSticky;
+  styleStringFor = styleStringFor;
 }
 ```
 

--- a/docs/plugins/sticky-column/demo/demo-a.md
+++ b/docs/plugins/sticky-column/demo/demo-a.md
@@ -5,6 +5,7 @@
       <tr class="relative">
         {{#each this.table.columns as |column|}}
           <th
+            {{this.table.modifiers.columnHeader column}}
             class="{{if (this.isSticky column) 'bg-basement' 'bg-ground-floor'}}"
             style="{{this.styleStringFor column}}"
           >

--- a/docs/plugins/sticky-column/demo/demo-a.md
+++ b/docs/plugins/sticky-column/demo/demo-a.md
@@ -57,7 +57,11 @@ export default class extends Component {
     ],
     data: () => DATA,
     plugins: [
-      StickyColumns,
+      StickyColumns.with(() => ({
+        // See:
+        //  https://github.com/emberjs/rfcs/pull/883
+        workaroundForModifierTimingUpdateRFC883: true
+      })),
       ColumnResizing,
     ],
   });

--- a/ember-headless-table/src/plugins/sticky-columns/helpers.ts
+++ b/ember-headless-table/src/plugins/sticky-columns/helpers.ts
@@ -1,3 +1,5 @@
+import { htmlSafe } from '@ember/template';
+
 import { meta } from '../-private/base';
 import { StickyColumns } from './plugin';
 
@@ -9,3 +11,47 @@ export const isSticky = <DataType = unknown>(column: Column<DataType>) =>
 export const styleFor = <DataType = unknown>(
   column: Column<DataType>
 ): Partial<CSSStyleDeclaration> => meta.forColumn(column, StickyColumns).style;
+
+/**
+ * In this plugin, buth header and cells have the same styles,
+ * if applicable.
+ *
+ * Until this RFC https://github.com/emberjs/rfcs/pull/883
+ * is merged and implemented, we can't performantly
+ * use modifiers for apply styles.
+ *
+ * In the mean time, we'll need to append style strings, which is more work
+ * for consumers, but is a reasonable trade-off for now.
+ */
+export const styleStringFor = <DataType = unknown>(
+  column: Column<DataType>
+): ReturnType<typeof htmlSafe> => {
+  let columnMeta = meta.forColumn(column, StickyColumns);
+
+  let result = '';
+
+  if (columnMeta.isSticky) {
+    for (let [key, value] of Object.entries(columnMeta.style)) {
+      result += `${toStyle(key)}:${value};`;
+    }
+
+    result = ';' + result;
+  }
+
+  return htmlSafe(result);
+};
+
+/**
+ * the JS API for styles is camel case,
+ * but CSS is kebab-case. To save on complexity and
+ * amount of code, we have a super small conversion function
+ * for only the properties relevant to the sticky plugin.
+ */
+const toStyle = (key: string): string => {
+  switch (key) {
+    case 'zIndex':
+      return 'z-index';
+    default:
+      return key;
+  }
+};

--- a/ember-headless-table/src/plugins/sticky-columns/plugin.ts
+++ b/ember-headless-table/src/plugins/sticky-columns/plugin.ts
@@ -7,6 +7,8 @@ import { applyStyles } from '../-private/utils';
 import type { ColumnApi } from '[public-plugin-types]';
 import type { Column } from '[public-types]';
 
+const DEFAULT_Z_INDEX = '8';
+
 interface ColumnOptions {
   /**
    * Whether or not to enable stickiness on the column
@@ -44,27 +46,44 @@ export class StickyColumns extends BasePlugin<Signature> {
     column: ColumnMeta,
   };
 
+  conditionallyRemoveStyles = (element: HTMLElement) => {
+    if (element.style.getPropertyValue('position') === 'sticky') {
+      element.style.removeProperty('position');
+    }
+
+    if (element.style.getPropertyValue('left')) {
+      element.style.left = '';
+    }
+
+    if (element.style.getPropertyValue('right')) {
+      element.style.right = '';
+    }
+
+    if (element.style.zIndex === DEFAULT_Z_INDEX) {
+      element.style.zIndex = '';
+    }
+  };
+
   headerCellModifier = (element: HTMLElement, { column }: ColumnApi) => {
     let columnMeta = meta.forColumn(column, StickyColumns);
 
     if (columnMeta.isSticky) {
       applyStyles(element, columnMeta.style);
     } else {
-      if (element.style.getPropertyValue('position') === 'sticky') {
-        element.style.removeProperty('position');
-      }
+      this.conditionallyRemoveStyles(element);
+    }
+  };
 
-      if (element.style.getPropertyValue('left')) {
-        element.style.left = '';
-      }
+  /**
+   * Not yet supported. Pending Ember RFC #883
+   */
+  cellModifier = (element: HTMLElement, { column }: ColumnApi) => {
+    let columnMeta = meta.forColumn(column, StickyColumns);
 
-      if (element.style.getPropertyValue('right')) {
-        element.style.right = '';
-      }
-
-      if (element.style.zIndex === '8') {
-        element.style.zIndex = '';
-      }
+    if (columnMeta.isSticky) {
+      applyStyles(element, columnMeta.style);
+    } else {
+      this.conditionallyRemoveStyles(element);
     }
   };
 }
@@ -136,7 +155,7 @@ export class ColumnMeta {
       return {
         position: 'sticky',
         [this.position]: this.offset,
-        zIndex: '8',
+        zIndex: DEFAULT_Z_INDEX,
       };
     }
 

--- a/ember-headless-table/src/plugins/sticky-columns/plugin.ts
+++ b/ember-headless-table/src/plugins/sticky-columns/plugin.ts
@@ -22,6 +22,15 @@ interface ColumnOptions {
 export interface Signature {
   Options: {
     Column: ColumnOptions;
+    Plugin: {
+      /**
+       * Opts this plugin out of engaging in the modifier system
+       * and instead requires setting a `style` attribute on
+       * th / td tags for getting the "position: sticky" behovior
+       * on columns.
+       */
+      workaroundForModifierTimingUpdateRFC883?: boolean;
+    };
   };
   Meta: {
     Table: TableMeta;
@@ -64,7 +73,11 @@ export class StickyColumns extends BasePlugin<Signature> {
     }
   };
 
-  headerCellModifier = (element: HTMLElement, { column }: ColumnApi) => {
+  headerCellModifier = (element: HTMLElement, { column, table }: ColumnApi) => {
+    if (options.forTable(table, StickyColumns).workaroundForModifierTimingUpdateRFC883) {
+      return;
+    }
+
     let columnMeta = meta.forColumn(column, StickyColumns);
 
     if (columnMeta.isSticky) {
@@ -76,8 +89,14 @@ export class StickyColumns extends BasePlugin<Signature> {
 
   /**
    * Not yet supported. Pending Ember RFC #883
+   *
+   * TODO: switch ColumnApi to "RowApi", add the row's data
    */
-  cellModifier = (element: HTMLElement, { column }: ColumnApi) => {
+  cellModifier = (element: HTMLElement, { column, table }: ColumnApi) => {
+    if (options.forTable(table, StickyColumns).workaroundForModifierTimingUpdateRFC883) {
+      return;
+    }
+
     let columnMeta = meta.forColumn(column, StickyColumns);
 
     if (columnMeta.isSticky) {

--- a/test-app/tests/plugins/sticky-columns/rendering-rfc-883-test.gts
+++ b/test-app/tests/plugins/sticky-columns/rendering-rfc-883-test.gts
@@ -7,7 +7,7 @@ import { setupRenderingTest } from 'ember-qunit';
 
 import { headlessTable, type ColumnConfig } from 'ember-headless-table';
 import { ColumnVisibility } from 'ember-headless-table/plugins/column-visibility';
-import { StickyColumns, isSticky } from 'ember-headless-table/plugins/sticky-columns';
+import { StickyColumns, isSticky, styleStringFor } from 'ember-headless-table/plugins/sticky-columns';
 import { ColumnReordering } from 'ember-headless-table/plugins/column-reordering';
 import { ColumnResizing } from 'ember-headless-table/plugins/column-resizing';
 import { createHelpers } from 'ember-headless-table/test-support';
@@ -122,7 +122,12 @@ module('Plugins | StickyColumns', function (hooks) {
           <thead>
             <tr class="relative">
               {{#each this.table.columns as |column|}}
-                <th data-sticky="{{isSticky column}}" data-key={{column.key}} {{this.table.modifiers.columnHeader column}}>
+                <th
+                  data-sticky="{{isSticky column}}"
+                  data-key={{column.key}}
+                  style={{styleStringFor column}}
+                  {{this.table.modifiers.columnHeader column}}
+                >
                   <span class="name">{{column.name}}</span><br>
                 </th>
               {{/each}}
@@ -132,7 +137,11 @@ module('Plugins | StickyColumns', function (hooks) {
             {{#each this.table.rows as |row|}}
               <tr class="relative">
                 {{#each this.table.columns as |column|}}
-                  <td data-sticky="{{isSticky column}}" {{this.table.modifiers.columnHeader column}}>
+                  <td
+                    data-sticky="{{isSticky column}}"
+                    style={{styleStringFor column}}
+                    {{this.table.modifiers.columnHeader column}}
+                  >
                     {{column.getValueForRow row}}
                   </td>
                 {{/each}}

--- a/test-app/tests/plugins/sticky-columns/rendering-rfc-883-test.gts
+++ b/test-app/tests/plugins/sticky-columns/rendering-rfc-883-test.gts
@@ -1,0 +1,494 @@
+import Component from '@glimmer/component';
+import { setOwner } from '@ember/application';
+import { assert, assert as debugAssert } from '@ember/debug';
+import { render, find } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+
+import { headlessTable, type ColumnConfig } from 'ember-headless-table';
+import { ColumnVisibility } from 'ember-headless-table/plugins/column-visibility';
+import { StickyColumns, isSticky } from 'ember-headless-table/plugins/sticky-columns';
+import { ColumnReordering } from 'ember-headless-table/plugins/column-reordering';
+import { ColumnResizing } from 'ember-headless-table/plugins/column-resizing';
+import { createHelpers } from 'ember-headless-table/test-support';
+import { DATA } from 'test-app/data';
+
+const minWidth = () => ColumnResizing.forColumn(() => ({ minWidth: 200 }));
+const leftSticky = () => StickyColumns.forColumn(() => ({ sticky: 'left' }));
+const rightSticky = () => StickyColumns.forColumn(() => ({ sticky: 'right' }));
+
+module('Plugins | StickyColumns', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let ctx: TestSetup;
+  let helpers = createHelpers({
+    scrollContainer: '[data-container]',
+  });
+
+  /**
+    * Used to account for pixel math rounding errors due to browser zoom, or other off-by-a-px errors
+    */
+  let isAbout = (testNumber: number, num: number, slop: number = 2) => {
+    return (testNumber <= num + slop) &&  (testNumber >= num - slop);
+  }
+
+  let leftPositionOf = (key: string) => {
+    let container = find('[data-container]');
+
+    assert(`[data-container] not found`, container instanceof HTMLElement);
+
+    let column = find(`[data-key=${key}]`);
+
+    assert(`[data-key=${key}] not found`, column instanceof HTMLElement);
+
+    let containerRect = container.getBoundingClientRect();
+    let columnRect = column.getBoundingClientRect();
+
+    let delta = columnRect.left - containerRect.left;
+
+    return delta;
+  }
+
+  let rightPositionOf = (key: string) => {
+    let container = find('[data-container]');
+
+    assert(`[data-container] not found`, container instanceof HTMLElement);
+
+    let column = find(`[data-key=${key}]`);
+
+    assert(`[data-key=${key}] not found`, column instanceof HTMLElement);
+
+    let containerRect = container.getBoundingClientRect();
+    let columnRect = column.getBoundingClientRect();
+    let delta = columnRect.right - containerRect.right;
+
+    return delta;
+  }
+
+  class TestSetup {
+    /**
+      * All columns set to min-width of 200 for easier math
+      * 7 columns @ 200px min is 1400px
+      */
+    columns: ColumnConfig<typeof DATA[number]>[] = [
+      { name: 'A', key: 'A', pluginOptions: [minWidth()] },
+      { name: 'B', key: 'B', pluginOptions: [minWidth()] },
+      { name: 'C', key: 'C', pluginOptions: [minWidth()] },
+      { name: 'D', key: 'D', pluginOptions: [minWidth()] },
+      { name: 'E', key: 'E', pluginOptions: [minWidth()] },
+      { name: 'F', key: 'F', pluginOptions: [minWidth()] },
+      { name: 'G', key: 'G', pluginOptions: [minWidth()] },
+    ];
+
+    table = headlessTable(this, {
+      columns: () => this.columns,
+      data: () => DATA,
+      plugins: [ColumnVisibility, ColumnReordering, ColumnResizing, StickyColumns.with(() => ({ workaroundForModifierTimingUpdateRFC883: true }))],
+    });
+  }
+
+  const TestStyles = <template>
+    <style>
+      #ember-testing { width: initial; height: initial; transform: initial; }
+      #ember-testing-container { width: 1000px; }
+
+      /*
+        * both of these are needed to get rid of browser-specific spacing
+        * so that we can do math easier
+        **/
+      table {
+        border-collapse: collapse;
+      }
+      table, table * {
+        box-sizing: border-box;
+      }
+
+      [data-sticky="true"] {
+        background: white;
+        z-index: 8;
+      }
+    </style>
+  </template>;
+
+  class TestComponent extends Component<{ Args: { ctx: TestSetup } }> {
+    get table() {
+      return this.args.ctx.table;
+    }
+
+    <template>
+      {{! with min-column @ 200px, this is 4 columns }}
+      <div data-container style="width: 800px; overflow: auto;" {{this.table.modifiers.container}}>
+        <table>
+          <thead>
+            <tr class="relative">
+              {{#each this.table.columns as |column|}}
+                <th data-sticky="{{isSticky column}}" data-key={{column.key}} {{this.table.modifiers.columnHeader column}}>
+                  <span class="name">{{column.name}}</span><br>
+                </th>
+              {{/each}}
+            </tr>
+          </thead>
+          <tbody>
+            {{#each this.table.rows as |row|}}
+              <tr class="relative">
+                {{#each this.table.columns as |column|}}
+                  <td data-sticky="{{isSticky column}}" {{this.table.modifiers.columnHeader column}}>
+                    {{column.getValueForRow row}}
+                  </td>
+                {{/each}}
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      </div>
+    </template>
+  }
+
+  module('with default options', function (hooks) {
+    hooks.beforeEach(function() {
+      ctx = new TestSetup();
+      setOwner(ctx, this.owner);
+    });
+
+    test('no columns are sticky', async function (assert) {
+      await render(<template>
+        <TestStyles />
+        <TestComponent @ctx={{ctx}} />
+      </template>);
+
+      /**
+        * If we haven't scrolled, the left column should share a left boundary at most within 1 pixel of
+        * its container
+        */
+      let left = leftPositionOf('A');
+      assert.ok(isAbout(left, 1), `A's left edge (@ ${left}) matches the left edge of the container`);
+
+      await helpers.scrollRight(200);
+
+      /**
+        * Because we only scrolled the distance of one column for this test,
+        * it doesn't make sense to check the other columns.
+        */
+      left = leftPositionOf('A');
+      assert.ok(isAbout(left, -200), `A's left edge (@ ${left}) moved, so it's not sticky`);
+    });
+  });
+
+  module('the left column can be sticky', function (hooks) {
+    class LeftColumn extends TestSetup {
+      columns = [
+        { name: 'column A', key: 'A', pluginOptions: [leftSticky(), minWidth()] },
+        { name: 'column B', key: 'B', pluginOptions: [minWidth()] },
+        { name: 'column C', key: 'C', pluginOptions: [minWidth()] },
+        { name: 'column D', key: 'D', pluginOptions: [minWidth()] },
+        { name: 'column E', key: 'E', pluginOptions: [minWidth()] },
+        { name: 'column F', key: 'F', pluginOptions: [minWidth()] },
+        { name: 'column G', key: 'G', pluginOptions: [minWidth()] },
+      ]
+    }
+
+    hooks.beforeEach(function() {
+      ctx = new LeftColumn();
+      setOwner(ctx, this.owner);
+    });
+
+    test('the left column does not change position during scrolling', async function (assert) {
+      await render(<template>
+        <TestStyles />
+        <TestComponent @ctx={{ctx}} />
+      </template>);
+
+      /**
+        * If we haven't scrolled, the left column should share a left boundary at most within 1 pixel of
+        * its container
+        */
+      let leftA = leftPositionOf('A');
+      assert.ok(isAbout(leftA, 1), `A's left edge (@ ${leftA}) matches the left edge of the container`);
+
+      let leftB = leftPositionOf('B');
+      assert.ok(isAbout(leftB, 201), `B's left edge (@ ${leftB}) is one column's width right of A`);
+
+      await helpers.scrollRight(200);
+
+      leftA = leftPositionOf('A');
+      assert.ok(isAbout(leftA, 0), `A's left edge (@ ${leftA}) is stuck to the left`);
+      leftB = leftPositionOf('B');
+      assert.ok(isAbout(leftB, 1), `B's left edge (@ ${leftB}) now shares an edge with A, due to scrolling`);
+    });
+
+  });
+
+  module('the right column can be sticky', function (hooks) {
+    class RightColumn extends TestSetup {
+      columns = [
+        { name: 'column A', key: 'A', pluginOptions: [minWidth()] },
+        { name: 'column B', key: 'B', pluginOptions: [minWidth()] },
+        { name: 'column C', key: 'C', pluginOptions: [minWidth()] },
+        { name: 'column D', key: 'D', pluginOptions: [minWidth()] },
+        { name: 'column E', key: 'E', pluginOptions: [minWidth()] },
+        { name: 'column F', key: 'F', pluginOptions: [minWidth()] },
+        { name: 'column G', key: 'G', pluginOptions: [minWidth(), rightSticky()] },
+      ]
+    }
+
+    hooks.beforeEach(function() {
+      ctx = new RightColumn();
+      setOwner(ctx, this.owner);
+    });
+
+    test('the right column does not change position during scrolling', async function (assert) {
+      await render(<template>
+        <TestStyles />
+        <TestComponent @ctx={{ctx}} />
+      </template>);
+
+      /**
+        * If we haven't scrolled, the right column should share a right boundary at most within 1 pixel of
+        * its container
+        */
+      let rightG = rightPositionOf('G');
+      assert.ok(isAbout(rightG, 0), `G's right edge (@ ${rightG}) matches the right edge of the container`);
+
+      let rightD = rightPositionOf('D');
+      assert.ok(isAbout(rightD, 0), `D's right edge (@ ${rightD}) matches the right edge of the container`);
+
+      let rightF = rightPositionOf('F');
+      assert.ok(
+        isAbout(rightF, 400),
+        `F's right edge (@ ${rightF}) is beyond the boundary of the container, as only 4 columns are visible at a time`
+      );
+
+      await helpers.swipeLeft(200);
+
+      rightG = rightPositionOf('G');
+      assert.ok(isAbout(rightG, 0), `G's right edge (@ ${rightG}) is stuck to the right`);
+
+      rightD = rightPositionOf('D');
+      assert.ok(isAbout(rightD, -200), `D's right edge (@ ${rightD}) now shares an edge with G, due to scrolling`);
+
+      await helpers.swipeLeft(2000);
+      rightG = rightPositionOf('G');
+      assert.ok(isAbout(rightG, 0), `G's right edge (@ ${rightG}) hasn't moved`);
+
+      rightF = rightPositionOf('F');
+      assert.ok(isAbout(rightF, -200), `F's right edge (@ ${rightF}) now shares an edge with G, due to scrolling`);
+    });
+  });
+
+  module('2 left columns can be sticky', function (hooks) {
+    class LeftColumn extends TestSetup {
+      columns = [
+        { name: 'column A', key: 'A', pluginOptions: [leftSticky(), minWidth()] },
+        { name: 'column B', key: 'B', pluginOptions: [leftSticky(), minWidth()] },
+        { name: 'column C', key: 'C', pluginOptions: [minWidth()] },
+        { name: 'column D', key: 'D', pluginOptions: [minWidth()] },
+        { name: 'column E', key: 'E', pluginOptions: [minWidth()] },
+        { name: 'column F', key: 'F', pluginOptions: [minWidth()] },
+        { name: 'column G', key: 'G', pluginOptions: [minWidth()] },
+      ]
+    }
+
+    hooks.beforeEach(function() {
+      ctx = new LeftColumn();
+      setOwner(ctx, this.owner);
+    });
+
+    test('the 2 left columns do not change position during scrolling', async function (assert) {
+      await render(<template>
+        <TestStyles />
+        <TestComponent @ctx={{ctx}} />
+      </template>);
+
+      /**
+        * If we haven't scrolled, the left column should share a left boundary at most within 1 pixel of
+        * its container
+        */
+      let leftA = leftPositionOf('A');
+      assert.ok(isAbout(leftA, 1), `A's left edge (@ ${leftA}) matches the left edge of the container`);
+
+      let leftB = leftPositionOf('B');
+      assert.ok(isAbout(leftB, 200), `B's left edge (@ ${leftB}) is one column's width right of A`);
+
+      let leftC = leftPositionOf('C');
+      assert.ok(isAbout(leftC, 400), `C's left edge (@ ${leftC}) is two column's width right of A`);
+
+      let leftD = leftPositionOf('D');
+      assert.ok(isAbout(leftD, 600), `D's left edge (@ ${leftD}) is three column's width right of A`);
+
+      await helpers.scrollRight(200);
+
+      leftA = leftPositionOf('A');
+      assert.ok(isAbout(leftA, 0), `A's left edge (@ ${leftA}) is stuck to the left`);
+      leftB = leftPositionOf('B');
+      assert.ok(isAbout(leftB, 200), `B's left edge (@ ${leftB}) is stuck to the left, but right of A`);
+
+      leftC = leftPositionOf('C');
+      assert.ok(isAbout(leftC, 200), `C's left edge (@ ${leftC}) has almost scrolled all the way to A's right edge`);
+
+      leftD = leftPositionOf('D');
+      assert.ok(isAbout(leftD, 400), `D's left edge (@ ${leftD}) is now where C's left edge used to be`);
+
+      await helpers.swipeLeft(200);
+
+      leftA = leftPositionOf('A');
+      assert.ok(isAbout(leftA, 0), `A's left edge (@ ${leftA}) has not moved.`);
+      leftB = leftPositionOf('B');
+      assert.ok(isAbout(leftB, 200), `B's left edge (@ ${leftB}) has not moved.`);
+
+      leftC = leftPositionOf('C');
+      assert.ok(isAbout(leftC, 0), `C's left edge (@ ${leftC}) is almost as left as it can go`);
+
+      leftD = leftPositionOf('D');
+      assert.ok(isAbout(leftD, 200), `D's left edge (@ ${leftD}) is now where C's left edge used to be (again)`);
+    });
+  });
+
+  module('2 right columns can be sticky', function (hooks) {
+    class RightColumn extends TestSetup {
+      columns = [
+        { name: 'column A', key: 'A', pluginOptions: [minWidth()] },
+        { name: 'column B', key: 'B', pluginOptions: [minWidth()] },
+        { name: 'column C', key: 'C', pluginOptions: [minWidth()] },
+        { name: 'column D', key: 'D', pluginOptions: [minWidth()] },
+        { name: 'column E', key: 'E', pluginOptions: [minWidth()] },
+        { name: 'column F', key: 'F', pluginOptions: [minWidth(), rightSticky()] },
+        { name: 'column G', key: 'G', pluginOptions: [minWidth(), rightSticky()] },
+      ]
+    }
+
+    hooks.beforeEach(function() {
+      ctx = new RightColumn();
+      setOwner(ctx, this.owner);
+    });
+
+
+    test('the 2 right columns do not change position during scrolling', async function (assert) {
+      await render(<template>
+        <TestStyles />
+        <TestComponent @ctx={{ctx}} />
+      </template>);
+
+      /**
+        * If we haven't scrolled, the right two columns should share a right boundary at most within 1 pixel of
+        * its neighbor / container
+        */
+      let rightG = rightPositionOf('G');
+      assert.ok(isAbout(rightG, 0), `G's right edge (@ ${rightG}) matches the right edge of the container`);
+
+      let rightF = rightPositionOf('F');
+      assert.ok(
+        isAbout(rightF, -200),
+        `F's right edge (@ ${rightF}) is one column's width to the left container`);
+
+      let rightE = rightPositionOf('E');
+      assert.ok(isAbout(rightE, 200), `E's right edge (@ ${rightE}) is one column's width beyond the container's right edge`);
+
+      let rightD = rightPositionOf('D');
+      assert.ok(
+        isAbout(rightD, 0),
+        `D's right edge (@ ${rightD}) matches the right edge of the container, `
+        + `and would be hidden by being underneath column G`
+      );
+
+      await helpers.swipeLeft(200);
+
+      rightG = rightPositionOf('G');
+      assert.ok(isAbout(rightG, 0), `G's right edge (@ ${rightG}) is stuck to the right`);
+
+      rightF = rightPositionOf('F');
+      assert.ok(isAbout(rightF, -200), `F's right edge (@ ${rightF}) has not moved`);
+
+      rightE = rightPositionOf('E');
+      assert.ok(isAbout(rightE, 0), `E's right edge (@ ${rightE}) now matches the boundary, but is covered by G`);
+
+      rightD = rightPositionOf('D');
+      assert.ok(
+        isAbout(rightD, -200),
+        `D's right edge (@ ${rightD}) now shares an edge with G, due to scrolling. `
+        + `This column should be underneath column F`
+      );
+
+      await helpers.swipeLeft(2000);
+      rightG = rightPositionOf('G');
+      assert.ok(isAbout(rightG, 0), `G's right edge (@ ${rightG}) hasn't moved`);
+
+      rightF = rightPositionOf('F');
+      assert.ok(isAbout(rightF, -200), `F's right edge (@ ${rightF}) hasn't moved`);
+
+      rightE = rightPositionOf('E');
+      assert.ok(isAbout(rightE, -400), `E's right edge (@ ${rightE}) is now shared with sticky column F's left edge`);
+
+      rightD = rightPositionOf('D');
+      assert.ok(isAbout(rightD, -600), `D's right edge (@ ${rightD}) is all the way on the left`);
+    });
+  });
+
+  module('columns on both ends can be sticky', function (hooks) {
+    class EndColumns extends TestSetup {
+      columns = [
+        { name: 'column A', key: 'A', pluginOptions: [minWidth(), leftSticky()] },
+        { name: 'column B', key: 'B', pluginOptions: [minWidth()] },
+        { name: 'column C', key: 'C', pluginOptions: [minWidth()] },
+        { name: 'column D', key: 'D', pluginOptions: [minWidth()] },
+        { name: 'column E', key: 'E', pluginOptions: [minWidth()] },
+        { name: 'column F', key: 'F', pluginOptions: [minWidth()] },
+        { name: 'column G', key: 'G', pluginOptions: [minWidth(), rightSticky()] },
+      ]
+    }
+
+    hooks.beforeEach(function() {
+      ctx = new EndColumns();
+      setOwner(ctx, this.owner);
+    });
+
+
+    test('both sticky columns do not change position during scrolling', async function (assert) {
+      await render(<template>
+        <TestStyles />
+        <TestComponent @ctx={{ctx}} />
+      </template>);
+
+      /**
+        * The sticky columns
+        */
+      let leftA = leftPositionOf('A');
+      assert.ok(isAbout(leftA, 1), `A's left edge (@ ${leftA}) matches the left edge of the container`);
+
+      let rightG = rightPositionOf('G');
+      assert.ok(isAbout(rightG, 0), `G's right edge (@ ${rightG}) matches the right edge of the container`);
+
+      /**
+        * The columns immediately adjacent to the sticky columns
+        */
+      let leftB = leftPositionOf('B');
+      assert.ok(isAbout(leftB, 201), `B's left edge (@ ${leftB}) is one column's width right of A`);
+
+      let rightF = rightPositionOf('F');
+      assert.ok(
+        isAbout(rightF, 400),
+        `F's right edge (@ ${rightF}) is beyond the boundary of the container, as only 4 columns are visible at a time`
+      );
+
+      await helpers.swipeLeft(200);
+
+
+      /**
+        * The sticky columns
+        */
+      leftA = leftPositionOf('A');
+      assert.ok(isAbout(leftA, 0), `A's left edge (@ ${leftA}) is stuck to the left`);
+
+      rightG = rightPositionOf('G');
+      assert.ok(isAbout(rightG, 0), `G's right edge (@ ${rightG}) is stuck to the right`);
+
+      /**
+        * The columns immediately adjacent to the sticky columns
+        */
+      leftB = leftPositionOf('B');
+      assert.ok(isAbout(leftB, 1), `B's left edge (@ ${leftB}) now shares an edge with A, due to scrolling`);
+
+      rightF = rightPositionOf('F');
+      assert.ok(isAbout(rightF, 200), `F's right edge (@ ${rightF}) is still beyond the boundary of the container, but less so`);
+    });
+  });
+});

--- a/test-app/tests/plugins/sticky-columns/rendering-rfc-883-test.gts
+++ b/test-app/tests/plugins/sticky-columns/rendering-rfc-883-test.gts
@@ -17,7 +17,7 @@ const minWidth = () => ColumnResizing.forColumn(() => ({ minWidth: 200 }));
 const leftSticky = () => StickyColumns.forColumn(() => ({ sticky: 'left' }));
 const rightSticky = () => StickyColumns.forColumn(() => ({ sticky: 'right' }));
 
-module('Plugins | StickyColumns', function (hooks) {
+module('Plugins | StickyColumns | RFC#883 work-around', function (hooks) {
   setupRenderingTest(hooks);
 
   let ctx: TestSetup;


### PR DESCRIPTION
re-introducing using a style string (concatenated, per plugin) until emberjs/rfcs#883 lands and is implemented.

Typically, you'd just want to let the plugin modifiers do everything, but because the sticky column / pinned columns plugin causes layout / re-paints, we want to use the style attribute to reduce the amount of content flashes for the user.

The sticky columns plugin was _initially_ implemented in this way, but was removed due to awkwardness around trying to come up with a unified API for applying styles to the style attribute across all plugins (and that's how the modifier approach came to be).

This new(yet old!) approach is specific to the sticky columns plugin, and style attribute setting is not an inherent plugin feature (as it's a one part too much wiring, as the modifiers should be able to handle it long term (esp once emberjs/rfcs#883 is implemented)). 

**Test Plan**

Visit: https://cfbd9de5.ember-headless-table.pages.dev/docs/plugins/sticky-column 
and ensure the demo's first and last column are still sticky to their respective sides of the table.

**once merged**

We'll see this PR update: https://github.com/CrowdStrike/ember-headless-table/pull/91
And I'll click `merge`, and all the release automation should "just work"