### PR TITLE
fix: toStyle, convert minWidth to min-width

### DIFF
--- a/.changeset/spotty-rats-love.md
+++ b/.changeset/spotty-rats-love.md
@@ -1,0 +1,5 @@
+---
+'ember-headless-table': patch
+---
+
+Bugfix, change minWidth to min-width for the Sticky columns plugin

--- a/ember-headless-table/src/plugins/sticky-columns/helpers.ts
+++ b/ember-headless-table/src/plugins/sticky-columns/helpers.ts
@@ -51,6 +51,8 @@ const toStyle = (key: string): string => {
   switch (key) {
     case 'zIndex':
       return 'z-index';
+    case 'minWidth':
+      return 'min-width';
     default:
       return key;
   }

--- a/test-app/tests/plugins/sticky-columns/rendering-rfc-883-test.gts
+++ b/test-app/tests/plugins/sticky-columns/rendering-rfc-883-test.gts
@@ -32,6 +32,14 @@ module('Plugins | StickyColumns | RFC#883 work-around', function (hooks) {
     return (testNumber <= num + slop) &&  (testNumber >= num - slop);
   }
 
+  let columnOf = (key: string) => {
+    let column = find(`[data-key=${key}]`);
+
+    assert(`[data-key=${key}] not found`, column instanceof HTMLElement);
+
+    return column;
+  }
+
   let leftPositionOf = (key: string) => {
     let container = find('[data-container]');
 
@@ -171,6 +179,12 @@ module('Plugins | StickyColumns | RFC#883 work-around', function (hooks) {
         */
       let left = leftPositionOf('A');
       assert.ok(isAbout(left, 1), `A's left edge (@ ${left}) matches the left edge of the container`);
+
+      const col = columnOf('A');
+
+      // https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration
+      // minWidth gets camelcased but this test is still valid for minWidth on the style attribute
+      assert.dom(col).hasStyle({minWidth: '200px'}, 'min-width renders correctly as style');
 
       await helpers.scrollRight(200);
 

--- a/test-app/tests/plugins/sticky-columns/rendering-rfc-883-test.gts
+++ b/test-app/tests/plugins/sticky-columns/rendering-rfc-883-test.gts
@@ -182,9 +182,7 @@ module('Plugins | StickyColumns | RFC#883 work-around', function (hooks) {
 
       const col = columnOf('A');
 
-      // https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration
-      // minWidth gets camelcased but this test is still valid for minWidth on the style attribute
-      assert.dom(col).hasStyle({minWidth: '200px'}, 'min-width renders correctly as style');
+      assert.dom(col).hasAttribute('style','width: 200px; min-width: 200px;', 'min-width renders correctly as style');
 
       await helpers.scrollRight(200);
 


### PR DESCRIPTION
# Description 
Some folks are having issues rendering the columns `minWidth` style because they style tag looks like:

```
style="minWidth: 40px"
```

Instead of:

```
style="min-width: 40px"
```

This hopefully fixes that?