### PR TITLE
Attempt to fix minification error

### DIFF
--- a/ember-headless-table/src/plugins/sticky-columns/helpers.ts
+++ b/ember-headless-table/src/plugins/sticky-columns/helpers.ts
@@ -13,6 +13,23 @@ export const styleFor = <DataType = unknown>(
 ): Partial<CSSStyleDeclaration> => meta.forColumn(column, StickyColumns).style;
 
 /**
+ * the JS API for styles is camel case,
+ * but CSS is kebab-case. To save on complexity and
+ * amount of code, we have a super small conversion function
+ * for only the properties relevant to the sticky plugin.
+ */
+export const toStyle = (key: string): string => {
+  switch (key) {
+    case 'zIndex':
+      return 'z-index';
+    case 'minWidth':
+      return 'min-width';
+    default:
+      return key;
+  }
+};
+
+/**
  * In this plugin, both header and cells have the same styles,
  * if applicable.
  *
@@ -41,19 +58,3 @@ export const styleStringFor = <DataType = unknown>(
   return htmlSafe(result);
 };
 
-/**
- * the JS API for styles is camel case,
- * but CSS is kebab-case. To save on complexity and
- * amount of code, we have a super small conversion function
- * for only the properties relevant to the sticky plugin.
- */
-const toStyle = (key: string): string => {
-  switch (key) {
-    case 'zIndex':
-      return 'z-index';
-    case 'minWidth':
-      return 'min-width';
-    default:
-      return key;
-  }
-};

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -29,7 +29,7 @@
     "ember-auto-import": "^2.6.2",
     "ember-cached-decorator-polyfill": "^1.0.1",
     "ember-functions-as-helper-polyfill": "^2.1.1",
-    "ember-headless-table": "workspace:../ember-headless-table",
+    "ember-headless-table": "workspace:*",
     "ember-resources": "^5.4.0",
     "tracked-built-ins": "^3.1.0"
   },


### PR DESCRIPTION
See issue:

![auto-import-problem](https://user-images.githubusercontent.com/771170/234131296-4b59fe94-5021-4a7e-955d-e67b1a33b456.gif)

1. I think this problem is with `ember-auto-import`
2. Because we don't export `toStyle` it's not showing up in the minified code.
3. So `minWidth` is not converted to `min-width`.

Related code that is missing (`toStyle`): https://github.com/CrowdStrike/ember-headless-table/blob/main/ember-headless-table/src/plugins/sticky-columns/helpers.ts#L35

## Potential workarounds
1. `export toStyle` so that it ends up in `ember-auto-import` build
2. move `toStyle` earlier in the file.