### PR TITLE
Compat with ember-source@v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
           - ember-lts-4.4
           - ember-lts-4.8
           - ember-lts-4.12
+          - ember-5.0.0
           - ember-release
           - ember-beta
           - ember-canary

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -50,6 +50,14 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-5.0.0',
+        npm: {
+          devDependencies: {
+            'ember-source': '~5.0.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
ember-source@v5 came out today.

I expect this will fail (initially), as back when I was adding TS v5 to the test matrix, here: https://github.com/CrowdStrike/ember-headless-table/pull/147
the beta and canary builds failed.

So, I'll see what issues are needed to be resolved here and open more PRs.

---------------------

For the general maintenance / upkeep on this repo, the review / merge order is the following:
1. https://github.com/CrowdStrike/ember-headless-table/pull/174
1. https://github.com/CrowdStrike/ember-headless-table/pull/147
1. https://github.com/CrowdStrike/ember-headless-table/pull/176
1. https://github.com/CrowdStrike/ember-headless-table/pull/175
1. https://github.com/CrowdStrike/ember-headless-table/pull/168

Each of these PRs, if rebased after the prior PR is merged, should go green.

Note, that, from forks, the publish to cloudflare will fail unless this publish strategy is adopted: https://github.com/NullVoxPopuli/limber/blob/main/.github/workflows/deploy-preview.yml