### PR TITLE
Drop support for TS <4.8, introduce TS support rolling-window-policy

### DIFF
--- a/.changeset/soft-wolves-own.md
+++ b/.changeset/soft-wolves-own.md
@@ -1,0 +1,10 @@
+---
+'ember-headless-table': major
+---
+
+In prepr for supporting Glint 1.0,
+ember-headless-table no longer will support TypeScript < 4.8.
+
+Additionally, the support policy is changing from a minimum version, to a [rolling window](https://www.semver-ts.org/#decouple-typescript-support-from-lts-cycles) policy, as described in https://semver-ts.org.
+
+The current and prior two TypeScript versions will be supported, giving a rolling window of 3 TypeScript versions.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,6 @@ jobs:
       fail-fast: true
       matrix:
         typescript-scenario:
-          - typescript@4.5
-          - typescript@4.6
-          - typescript@4.7
           - typescript@4.8
           - typescript@4.9
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ember install ember-headless-table
 * ember-auto-import >= v2
 * ember-source >= 3.28
 * embroider safe + optimized
-* typescript >= 4.5
+* typescript >= 4.8, [rolling window policy](https://www.semver-ts.org/#decouple-typescript-support-from-lts-cycles), range: TS@current-2 to TS@current (3 version window).
   Note that types changes will be considered bugfixes until Glint support is added to ember-headless-table
 * Glint -- not yet
   All Glint changes will be considered bugfixes until Glint 1.0 is released.


### PR DESCRIPTION
In order to officially support Glint, support for TS < 4.8 must be dropped as Glint only supports TS 4.8+.

> Removing a TypeScript version from the support matrix is a breaking change, except when it falls out of the supported version range under the “rolling support windows” policy.

https://www.semver-ts.org/
In particular: https://www.semver-ts.org/#decouple-typescript-support-from-lts-cycles

So, this is a good time to _adopt_ a TS rolling window support policy. 
Going from a min-version to rolling support window is a breaking change.

---------------------

For the general maintenance / upkeep on this repo, the review / merge order is the following:
1. https://github.com/CrowdStrike/ember-headless-table/pull/174
1. https://github.com/CrowdStrike/ember-headless-table/pull/147
1. https://github.com/CrowdStrike/ember-headless-table/pull/176
1. https://github.com/CrowdStrike/ember-headless-table/pull/175
1. https://github.com/CrowdStrike/ember-headless-table/pull/168

Each of these PRs, if rebased after the prior PR is merged, should go green.

Note, that, from forks, the publish to cloudflare will fail unless this publish strategy is adopted: https://github.com/NullVoxPopuli/limber/blob/main/.github/workflows/deploy-preview.yml