### PR TITLE
Demo deploys from forks  -- requires turbo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm
-
+      - run:  echo ${{ github.event.number }} > ./pr-number.txt
+      - run: pnpm turbo build
+      # Used for faster deploy so we don't need to checkout the repo
+      - uses: actions/upload-artifact@v3
+        with:
+          name: deploy-prep-dist
+          if-no-files-found: error
+          path: |
+            ./apps/**/dist/**/*
+            !node_modules/
+            !./**/node_modules/
 
 
 
@@ -193,55 +203,4 @@ jobs:
       - uses: ./.github/actions/download-built-package
       - run: pnpm glint
         working-directory: docs-app
-
-
-
-  PublishDocstoCloudflarePages:
-    name: Publish Docs to Cloudflare Pages
-    runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      contents: read
-      deployments: write
-    outputs:
-      url: ${{ steps.publishStep.outputs.url }}
-      env: ${{ steps.publishStep.outputs.environment }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/pnpm
-      - uses: ./.github/actions/download-built-package
-      - run: pnpm build:docs
-      - name: Publish to Cloudflare Pages
-        id: publishStep
-        uses: cloudflare/pages-action@1
-        with:
-          apiToken: ${{ secrets.UX_OSS_CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.UX_OSS_CLOUDFLARE_ACCOUNT_ID }}
-          projectName: ember-headless-table
-          directory: ./docs-app/dist
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-
-
-
-  PostPreviewURLascommenttoPR:
-    name: Post Preview URL as comment to PR
-    runs-on: ubuntu-latest
-    needs: PublishDocstoCloudflarePages
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/pnpm
-      - uses: ./.github/actions/download-built-package
-      - uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          message: |+
-            ## Preview URLs
-            GH Env: ${{ needs.PublishDocstoCloudflarePages.outputs.env }}
-            docs: ${{ needs.PublishDocstoCloudflarePages.outputs.url }}
-            api docs: ${{ needs.PublishDocstoCloudflarePages.outputs.url }}/api/modules.html
-
-
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,137 @@
+# Because C.I. jobs could expose secrets to malicious pull requsets,
+# GitHub prevents (by default) exposing action secrets to pull requests
+# from forks.
+#
+# This is great, however, the jobs that use the secrets are still useful on
+# pull requests.
+#
+# To run a _trusted_ workflow, we can trigger it from an event from an _untrusted_
+# workflow. This keeps the secrets out of reach from the fork, but still allows
+# us to keep the utility of pull request preview deploys, browserstack running, etc.
+# Normally, this _trusted_ behavior is offloaded by Cloudflare, Netlify, Vercel, etc
+# -- their own workers are trusted and can push comments / updates to pull requests.
+#
+# We don't want to use their slower (and sometimes paid) hardware.
+# When we use our own workflows, we can re-use the cache built from the PR
+# (or elsewhere).
+#
+# To be *most* secure, you'd need to build all the artifacts in the PR,
+# then upload them to then be downloaded in the trusted workflows.
+# Trusted workflows should not run any scripts from a PR, as malicious
+# submitters may tweak the build scripts.
+# Since all build artifacts are for the web browser, and not executed in
+# node-space, we can be reasonably confident that downloading and testing/deploying
+# those artifacts does not compromise our secrets.
+#
+#
+# More information here:
+#   https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+#
+# Things that would make this easier:
+#   Readablity: https://github.com/actions/download-artifact/issues/172
+#   Security:
+#    - if there was a way to avoid pnpm install *entirely*
+name: Deploy Preview
+
+# read-write repo token
+# access to secrets
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      # as early as possible
+      - requested
+
+concurrency:
+  group: deploy-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TURBO_API: http://127.0.0.1:9080
+  TURBO_TOKEN: this-is-not-a-secret
+  TURBO_TEAM: myself
+
+
+jobs:
+  # This is the only job that needs access to the source code
+  Build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [determinePR]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+      - name: TurboRepo local server
+        uses: felixmosh/turborepo-gh-artifacts@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: NullVoxPopuli/action-setup-pnpm@v2.1.0
+      - run: pnpm turbo build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: deploy-prep-dist
+          if-no-files-found: error
+          path: |
+            ./apps/**/dist/**/*
+            !node_modules/
+            !./**/node_modules/
+
+#################################################################
+# For the rest:
+# Does not checkout code, has access to secrets
+#################################################################
+
+  determinePR:
+    # this job gates the others -- if the workflow_run request did not come from a PR,
+    # exit as early as possible
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    outputs:
+      number: ${{ steps.number.outputs.pr-number }}
+    steps:
+      - run: echo "${{ toJSON(github.event.workflow_run) }}"
+      - run: echo "${{ github.event.workflow_run.pull_requests[0].number }}"
+        id: number
+
+  DeployPreview:
+    name: "Deploy: Preview"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [Build]
+    permissions:
+      contents: read
+      deployments: write
+    outputs:
+      url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - uses: actions/download-artifact@v3
+        name: deploy-prep-dist
+      - id: deploy
+        uses: cloudflare/pages-action@v1.4.1
+        with:
+          branch: ${{ github.event.workflow_run.head_branch }}
+          apiToken: ${{ secrets.UX_OSS_CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.UX_OSS_CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ember-headless-table
+          directory: ./docs-app/dist
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+  PostComment:
+    name: Post Preview URL as comment to PR
+    runs-on: ubuntu-latest
+    needs: [DeployPreview, determinePR]
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: preview-urls
+          number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          message: |+
+            | Project   | Preview URL |
+            | -------   | ----------- |
+            | Docs    | ${{ needs.DeployPreview.outputs.url }}   |
+            | API Docs  | ${{ needs.DeployPreview.outputs.url }}/api/modules.html |
+
+            [Logs](https://github.com/NullVoxPopuli/limber/actions/runs/${{ github.run_id }})


### PR DESCRIPTION
You can see this in action over at this repo: https://github.com/NullVoxPopuli/limber

Feel free to open a PR changing any of these files: https://github.com/NullVoxPopuli/limber/tree/main/apps/tutorial/docs

Note that this as copy-and-pasted from Limber requires turborepo.
The technique itself doesn't require turbo, as you only need to cache the dist outputs, but I didn't feel like doing that much tweaking atm :sweat_smile: 