### PR TITLE
Bulk column preferences reset

### DIFF
--- a/.changeset/lucky-ducks-hang.md
+++ b/.changeset/lucky-ducks-hang.md
@@ -1,0 +1,6 @@
+---
+"ember-headless-table": patch
+---
+
+Refactor to bulk reset column visibility preferences in a single call to
+the preferences service

--- a/ember-headless-table/src/plugins/-private/base.ts
+++ b/ember-headless-table/src/plugins/-private/base.ts
@@ -193,6 +193,33 @@ export const preferences = {
   /**
    * @public
    *
+   * returns an object for bulk updating preferences data
+   * for all columns (scoped to key and table)
+   */
+  forAllColumns<P extends BasePlugin<any>, Data = unknown>(table: Table<Data>, klass: Class<P>) {
+    return {
+      /**
+       * delete an entry on every column in the underlying column `Map` for this table-plugin pair
+       */
+      delete(key: string) {
+        let tablePrefs = table.preferences;
+
+        for (let column of table.columns) {
+          let prefs = column.table.preferences;
+          let existing = prefs.storage.forPlugin(klass.name);
+          let columnPrefs = existing.forColumn(column.key);
+
+          columnPrefs.delete(key);
+        }
+
+        return tablePrefs.persist();
+      },
+    };
+  },
+
+  /**
+   * @public
+   *
    * returns an object for getting and setting preferences data
    * based on the table (scoped to the key: "table")
    *

--- a/ember-headless-table/src/plugins/-private/base.ts
+++ b/ember-headless-table/src/plugins/-private/base.ts
@@ -203,7 +203,7 @@ export const preferences = {
   forTable<P extends BasePlugin<any>, Data = unknown>(table: Table<Data>, klass: Class<P>) {
     return {
       /**
-       * delete an entry on the underlying `Map` used for this column-plugin pair
+       * delete an entry on the underlying `Map` used for this table-plugin pair
        */
       delete(key: string) {
         let prefs = table.preferences;
@@ -214,7 +214,7 @@ export const preferences = {
         return prefs.persist();
       },
       /**
-       * get an entry on the underlying `Map` used for this column-plugin pair
+       * get an entry on the underlying `Map` used for this table-plugin pair
        */
       get(key: string) {
         let prefs = table.preferences;
@@ -223,7 +223,7 @@ export const preferences = {
         return existing.table.get(key);
       },
       /**
-       * set an entry on the underlying `Map` used for this column-plugin pair
+       * set an entry on the underlying `Map` used for this table-plugin pair
        */
       set(key: string, value: unknown) {
         let prefs = table.preferences;

--- a/ember-headless-table/src/plugins/column-visibility/plugin.ts
+++ b/ember-headless-table/src/plugins/column-visibility/plugin.ts
@@ -52,17 +52,7 @@ export class ColumnVisibility extends BasePlugin<Signature> implements Plugin<Si
   };
 
   reset() {
-    /**
-     * Global preference, not scoped to plugin
-     */
-    for (let column of this.table.columns) {
-      let defaultValue = options.forColumn(column, ColumnVisibility)?.isVisible;
-      let current = meta.forColumn(column, ColumnVisibility).isVisible;
-
-      if (defaultValue !== current) {
-        preferences.forColumn(column, ColumnVisibility).delete('isVisible');
-      }
-    }
+    preferences.forAllColumns(this.table, ColumnVisibility).delete('isVisible');
   }
 
   get columns() {


### PR DESCRIPTION
When resetting column visibility preferences, each column is currently reset
separately with it's own call to the preferences service.

This update simplifies the reset by adding the `forAllColumns.delete(key: string)` method.

This clears preferences for the given key for the ColumnVisibility plugin for all columns
in a single call.