### PR TITLE
Column Width Preference Calls

### DIFF
--- a/.changeset/fluffy-books-hope.md
+++ b/.changeset/fluffy-books-hope.md
@@ -1,0 +1,6 @@
+---
+"ember-headless-table": patch
+---
+
+Column widths are saved and reset in a single call to the preferences service,
+rather than on a per column basis, for improved UI performance

--- a/ember-headless-table/src/plugins/column-resizing/plugin.ts
+++ b/ember-headless-table/src/plugins/column-resizing/plugin.ts
@@ -303,19 +303,16 @@ export class TableMeta {
 
   @action
   saveColWidths(visibleColumnMetas: ColumnMeta[]) {
-    let availableColumns = columns.for(this.table, ColumnResizing);
+    let tablePrefs = this.table.preferences;
 
     for (let column of visibleColumnMetas) {
-      let columnToUpdate = availableColumns.find((c) => {
-        return c.key === column.key;
-      });
+      let existing = tablePrefs.storage.forPlugin('ColumnResizing');
+      let columnPrefs = existing.forColumn(column.key);
 
-      assert('column must exist', columnToUpdate);
-
-      let colPreferences = preferences.forColumn(columnToUpdate, ColumnResizing);
-
-      colPreferences.set('width', column.width.toString());
+      columnPrefs.set('width', column.width.toString());
     }
+
+    tablePrefs.persist();
   }
 
   @action

--- a/ember-headless-table/src/plugins/column-resizing/plugin.ts
+++ b/ember-headless-table/src/plugins/column-resizing/plugin.ts
@@ -97,7 +97,7 @@ export class ColumnResizing extends BasePlugin<Signature> {
   };
 
   /**
-   * This is what ends up calling resize when the browesr changes
+   * This is what ends up calling resize when the browser changes
    * (assuming that the containing element's styles stretch to fill the space)
    *
    * Later, when container queries are more broadly supported, we'll want to watch

--- a/ember-headless-table/src/plugins/column-resizing/plugin.ts
+++ b/ember-headless-table/src/plugins/column-resizing/plugin.ts
@@ -107,18 +107,7 @@ export class ColumnResizing extends BasePlugin<Signature> {
   containerModifier = resizeObserver;
 
   reset() {
-    let tableMeta = meta.forTable(this.table, ColumnResizing);
-
-    tableMeta.reset();
-
-    for (let column of this.table.columns) {
-      let defaultValue = options.forColumn(column, ColumnResizing)?.width;
-      let current = meta.forColumn(column, ColumnResizing).width;
-
-      if (defaultValue !== current) {
-        preferences.forTable(this.table, ColumnResizing).delete('width');
-      }
-    }
+    preferences.forAllColumns(this.table, ColumnResizing).delete('width');
   }
 }
 

--- a/test-app/tests/plugins/column-resizing/rendering-test.gts
+++ b/test-app/tests/plugins/column-resizing/rendering-test.gts
@@ -305,7 +305,7 @@ module('Plugins | resizing', function (hooks) {
             "table": {}
           }
         }
-      });
+      }, 'column widths saved in preferences');
     });
   });
 

--- a/test-app/tests/plugins/column-resizing/rendering-test.gts
+++ b/test-app/tests/plugins/column-resizing/rendering-test.gts
@@ -256,6 +256,47 @@ module('Plugins | resizing', function (hooks) {
       assert.equal(width(columnD), 200, 'col D has expected width');
     });
 
+    test('resetting clears preferences, and restores the original column width', async function (assert) {
+      await render(
+        <template>
+          <TestComponentA @ctx={{ctx}} />
+        </template>
+      )
+      const [columnA, columnB, columnC, columnD] = getColumns();
+
+      debugAssert(`columnA doesn't exist`, columnA);
+      debugAssert(`columnB doesn't exist`, columnB);
+      debugAssert(`columnC doesn't exist`, columnC);
+      debugAssert(`columnD doesn't exist`, columnD);
+
+      assert.equal(width(columnA), 300, 'col A has expected initial width');
+      assert.equal(width(columnB), 250, 'col B has expected initial width');
+      assert.equal(width(columnC), 250, 'col C has expected initial width');
+      assert.equal(width(columnD), 200, 'col D has expected initial width');
+
+      ctx.table.resetToDefaults();
+      await settled();
+
+      // Columns are set to equal widths, so column will be 250px wide by default
+      assert.equal(width(columnA), 250, 'col A has expected width after reset');
+      assert.equal(width(columnB), 250, 'col B has expected width after reset');
+      assert.equal(width(columnC), 250, 'col C has expected width after reset');
+      assert.equal(width(columnD), 250, 'col D has expected width after reset');
+      assert.deepEqual(preferences, {
+        "plugins": {
+          "ColumnResizing": {
+            "columns": {
+              "A": {},
+              "B": {},
+              "C": {},
+              "D": {}
+            },
+            "table": {}
+          }
+        }
+      }, 'All column preferences reset');
+    });
+
     test('it resizes each column', async function (assert) {
       // Columns are set to equal widths so each of the four columns
       // will initially be 250px wide in the 1000px wide container


### PR DESCRIPTION
Saving and resetting column width preferences after resizing on a per column basis was costly and led to unexpected and sub-optimal lag in the UI when there are a lot of columns in the table.

In this PR
- When columns are resized, all visible column widths are saved in a single call to the preferences service.
- When reset, all column widths preferences are deleted (as per column visibility preferences), in a single call to the preference service.
