### PR TITLE
chore: flaky test fixes

### DIFF
--- a/test-app/tests/plugins/column-resizing/column-options-test.gts
+++ b/test-app/tests/plugins/column-resizing/column-options-test.gts
@@ -201,6 +201,8 @@ module('Plugins | resizing | column options', function (hooks) {
           ]
         );
 
+        await requestAnimationFrameSettled();
+
         await assertChanges(
           () => dragLeft(columnC, 10),
           [

--- a/test-app/tests/plugins/column-resizing/rendering-test.gts
+++ b/test-app/tests/plugins/column-resizing/rendering-test.gts
@@ -275,7 +275,7 @@ module('Plugins | resizing', function (hooks) {
       assert.equal(width(columnD), 200, 'col D has expected initial width');
 
       ctx.table.resetToDefaults();
-      await settled();
+      await requestAnimationFrameSettled();
 
       // Columns are set to equal widths, so column will be 250px wide by default
       assert.equal(width(columnA), 250, 'col A has expected width after reset');
@@ -391,6 +391,8 @@ module('Plugins | resizing', function (hooks) {
             { value: () => width(columnD), by: 0, msg: 'width of D unchanged' },
           ]
         );
+
+        await requestAnimationFrameSettled();
 
         await assertChanges(
           () => dragLeft(columnB, 10),


### PR DESCRIPTION
await `requestAnimationFrameSettled()` before checking column width values in the DOM

some resizing tests were a bit flaky not returning the expected column widths. eg. on resetting four columns in a 1000px container the test would sometimes return the col widths as 128px (the min) rather than the expected (250px - 1/4 of the overall container width). I suspect that this is due to the test checking before the full reset and new width calculation was complete and the table fully rendered and settled.

