### PR TITLE
fix: Resize plugin, add destroy check

### DIFF
--- a/.changeset/fresh-oranges-scream.md
+++ b/.changeset/fresh-oranges-scream.md
@@ -1,0 +1,7 @@
+---
+'ember-headless-table': patch
+---
+
+Bugfix: the plugin for resize was not checking if the table was destroyed first.
+
+This fixes that so the observer is not listening for a removed table, which was causing an error in the preferences (since it was trying to set preferences for a table which is not on screen)

--- a/ember-headless-table/src/plugins/column-resizing/plugin.ts
+++ b/ember-headless-table/src/plugins/column-resizing/plugin.ts
@@ -1,5 +1,6 @@
 import { cached, tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
+import { isDestroyed, isDestroying } from '@ember/destroyable';
 import { action } from '@ember/object';
 
 import { preferences } from '[public-plugin-types]';
@@ -435,6 +436,10 @@ function getObserver(element: HTMLElement, table: Table): ResizeObserver {
   if (existing) return existing;
 
   existing = new ResizeObserver((entries: ResizeObserverEntry[]) => {
+    if (isDestroyed(table) || isDestroying(table)) {
+      return;
+    }
+
     for (let entry of entries) {
       meta.forTable(table, ColumnResizing).onTableResize(entry);
     }


### PR DESCRIPTION
Similar to: https://github.com/CrowdStrike/ember-headless-table/blob/02b84b0069e621bfcf1b9439206c7043c9dd7dc0/ember-headless-table/src/plugins/column-resizing/resize-observer.ts#L38

The ResizeObserver checks to see if the table is destroyed, if it is, it does not create a new ResizeObserver.

This is missing in the plugin, which causes this error: `Uncaught Error: You attempted to get the value of a helper after the helper was destroyed, which is not allowed`