### PR TITLE
Resize preference save sequence

### DIFF
--- a/.changeset/fair-laws-serve.md
+++ b/.changeset/fair-laws-serve.md
@@ -1,0 +1,6 @@
+---
+"ember-headless-table": patch
+---
+
+Fixes column resize and preference save sequencing
+to ensure that the functions always run in the correct order.

--- a/ember-headless-table/src/test-support/index.ts
+++ b/ember-headless-table/src/test-support/index.ts
@@ -28,18 +28,9 @@ export function createHelpers(selectors: Selectors) {
 
     triggerEvent(element, 'mousedown', { clientX: startX, button: 0 });
     triggerEvent(element, 'mousemove', { clientX: targetX, button: 0 });
-
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
     triggerEvent(element, 'mouseup', { clientX: targetX, button: 0 });
 
     await settled();
-
-    /**
-     * This has been super finnicky... :(
-     */
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    await requestAnimationFrameSettled();
   }
 
   function horizontalScrollElement() {


### PR DESCRIPTION
Turns out that this: https://github.com/CrowdStrike/ember-headless-table/pull/211#discussion_r1283447227 came back to bite us! The test was passing, but waiting in the test-helper was masking the resizing behaviour and causing unpredictable column resizing when interacting with tables.

**What was happening:**
Calling the resize function via a `requestAnimationFrame` in the `queueUpdate` pushes it into the next animation frame, however, the call to save the preferences was then happening ahead of it, so the saved values did not reflect the resizing.

We'd created a pseudo-async sequence.

**How these changes fix it:**
So, to ensure that preferences are saved after we have completed resizing, we pass the save function as a callback to the queueUpdate that can then be called in the requestAnimationFrame callback after the resize function.

Because the requestAnimationFrame _hides_ these function call from he ember test waiter, we ensure that we track them by also cancelling the waiter in the requestAnimationFrame callback function.