### PR TITLE
fix: update key for column resizing preferences

### DIFF
--- a/.changeset/eleven-experts-worry.md
+++ b/.changeset/eleven-experts-worry.md
@@ -1,0 +1,6 @@
+---
+"ember-headless-table": patch
+---
+
+Fixes key used to save column resizing preferences.
+A temporary patch ahead of fixing issue #238.

--- a/ember-headless-table/src/-private/preferences.ts
+++ b/ember-headless-table/src/-private/preferences.ts
@@ -63,6 +63,9 @@ class TrackedPreferences {
     return [...this.plugins.values()].every((pluginPrefs) => pluginPrefs.isAtDefault);
   }
 
+  /**
+   * @param {string} name - this needs to be provided as klass.name, eg ColumnResizing.name
+   */
   forPlugin(name: string) {
     let existing = this.plugins.get(name);
 

--- a/ember-headless-table/src/plugins/column-resizing/plugin.ts
+++ b/ember-headless-table/src/plugins/column-resizing/plugin.ts
@@ -307,7 +307,7 @@ export class TableMeta {
     let tablePrefs = this.table.preferences;
 
     for (let column of visibleColumnMetas) {
-      let existing = tablePrefs.storage.forPlugin('ColumnResizing');
+      let existing = tablePrefs.storage.forPlugin(ColumnResizing.name);
       let columnPrefs = existing.forColumn(column.key);
 
       columnPrefs.set('width', column.width.toString());


### PR DESCRIPTION
This is a temporary measure to ensure column width preferences are persisted with a key that can be used to retrieve them.
This is only needed until [issue#238](https://github.com/CrowdStrike/ember-headless-table/issues/238) is addressed