### PR TITLE
fix: link from docs to API documentation (#242)

### DIFF
--- a/docs-app/app/templates/application.hbs
+++ b/docs-app/app/templates/application.hbs
@@ -16,7 +16,7 @@
       </:title>
 
       <:links>
-        <ExternalLink @href="/api/modules.html" class="type-lg-medium">
+        <ExternalLink @href="/api/modules" class="type-lg-medium">
           API Documentation
         </ExternalLink>
 


### PR DESCRIPTION
fixes #242