### PR TITLE
fix: Use generic column types in resize-handle and data-sorting plugins (#247)

### DIFF
--- a/ember-headless-table/src/plugins/column-resizing/handle.ts
+++ b/ember-headless-table/src/plugins/column-resizing/handle.ts
@@ -24,7 +24,9 @@ let waiter = buildWaiter('ColumnResizing#ResizeHandle');
  *
  */
 
-class ResizeHandle<DataType = unknown> extends Modifier<{ Args: { Positional: [Column<DataType>] } }> {
+class ResizeHandle<DataType = unknown> extends Modifier<{ 
+  Args: { Positional: [Column<DataType>] }; 
+}> {
   declare dragHandle: HTMLElement;
   declare column: Column<DataType>;
   declare meta: ColumnMeta;

--- a/ember-headless-table/src/plugins/column-resizing/handle.ts
+++ b/ember-headless-table/src/plugins/column-resizing/handle.ts
@@ -24,8 +24,8 @@ let waiter = buildWaiter('ColumnResizing#ResizeHandle');
  *
  */
 
-class ResizeHandle<DataType = unknown> extends Modifier<{ 
-  Args: { Positional: [Column<DataType>] }; 
+class ResizeHandle<DataType = unknown> extends Modifier<{
+  Args: { Positional: [Column<DataType>] };
 }> {
   declare dragHandle: HTMLElement;
   declare column: Column<DataType>;

--- a/ember-headless-table/src/plugins/column-resizing/handle.ts
+++ b/ember-headless-table/src/plugins/column-resizing/handle.ts
@@ -24,9 +24,9 @@ let waiter = buildWaiter('ColumnResizing#ResizeHandle');
  *
  */
 
-class ResizeHandle<T> extends Modifier<{ Args: { Positional: [Column<T>] } }> {
+class ResizeHandle<DataType = unknown> extends Modifier<{ Args: { Positional: [Column<DataType>] } }> {
   declare dragHandle: HTMLElement;
-  declare column: Column<T>;
+  declare column: Column<DataType>;
   declare meta: ColumnMeta;
 
   // Pointer
@@ -45,7 +45,7 @@ class ResizeHandle<T> extends Modifier<{ Args: { Positional: [Column<T>] } }> {
   token?: unknown;
 
   isSetup = false;
-  modify(element: Element, [column]: [Column<T>]) {
+  modify(element: Element, [column]: [Column<DataType>]) {
     this.column = column;
     this.meta = meta.forColumn(column, ColumnResizing);
     this.dragHandle = element as HTMLElement;

--- a/ember-headless-table/src/plugins/column-resizing/handle.ts
+++ b/ember-headless-table/src/plugins/column-resizing/handle.ts
@@ -24,9 +24,9 @@ let waiter = buildWaiter('ColumnResizing#ResizeHandle');
  *
  */
 
-class ResizeHandle extends Modifier<{ Args: { Positional: [Column] } }> {
+class ResizeHandle<T> extends Modifier<{ Args: { Positional: [Column<T>] } }> {
   declare dragHandle: HTMLElement;
-  declare column: Column;
+  declare column: Column<T>;
   declare meta: ColumnMeta;
 
   // Pointer
@@ -45,7 +45,7 @@ class ResizeHandle extends Modifier<{ Args: { Positional: [Column] } }> {
   token?: unknown;
 
   isSetup = false;
-  modify(element: Element, [column]: [Column]) {
+  modify(element: Element, [column]: [Column<T>]) {
     this.column = column;
     this.meta = meta.forColumn(column, ColumnResizing);
     this.dragHandle = element as HTMLElement;

--- a/ember-headless-table/src/plugins/column-resizing/helpers.ts
+++ b/ember-headless-table/src/plugins/column-resizing/helpers.ts
@@ -15,13 +15,13 @@ import type { Column } from '[public-types]';
  * be marked as isResizing, because this is a user-scoped question:
  *   "Is the user directly resizing this column?"
  */
-export const isResizing = <DataType = unknown>(column: Column<DataType>) => 
+export const isResizing = <DataType = unknown>(column: Column<DataType>) =>
   meta.forColumn(column, ColumnResizing).isResizing;
 
 /**
  * Does the column have room to shrink?
  */
-export const canShrink = <DataType = unknown>(column: Column<DataType>) => 
+export const canShrink = <DataType = unknown>(column: Column<DataType>) =>
   meta.forColumn(column, ColumnResizing).canShrink;
 
 /**

--- a/ember-headless-table/src/plugins/column-resizing/helpers.ts
+++ b/ember-headless-table/src/plugins/column-resizing/helpers.ts
@@ -15,12 +15,12 @@ import type { Column } from '[public-types]';
  * be marked as isResizing, because this is a user-scoped question:
  *   "Is the user directly resizing this column?"
  */
-export const isResizing = (column: Column) => meta.forColumn(column, ColumnResizing).isResizing;
+export const isResizing = <DataType = unknown>(column: Column<DataType>) => meta.forColumn(column, ColumnResizing).isResizing;
 
 /**
  * Does the column have room to shrink?
  */
-export const canShrink = (column: Column) => meta.forColumn(column, ColumnResizing).canShrink;
+export const canShrink = <DataType = unknown>(column: Column<DataType>) => meta.forColumn(column, ColumnResizing).canShrink;
 
 /**
  * Does the column have a resize handle?
@@ -29,7 +29,7 @@ export const canShrink = (column: Column) => meta.forColumn(column, ColumnResizi
  *   - if resizing is enabled for the whole table
  *   - or if we're asking about the first column (resize handles may only be "between" columns)
  */
-export const hasResizeHandle = (column: Column) =>
+export const hasResizeHandle = <DataType = unknown>(column: Column<DataType>) =>
   meta.forColumn(column, ColumnResizing).hasResizeHandle;
 
 /**

--- a/ember-headless-table/src/plugins/column-resizing/helpers.ts
+++ b/ember-headless-table/src/plugins/column-resizing/helpers.ts
@@ -15,12 +15,14 @@ import type { Column } from '[public-types]';
  * be marked as isResizing, because this is a user-scoped question:
  *   "Is the user directly resizing this column?"
  */
-export const isResizing = <DataType = unknown>(column: Column<DataType>) => meta.forColumn(column, ColumnResizing).isResizing;
+export const isResizing = <DataType = unknown>(column: Column<DataType>) => 
+  meta.forColumn(column, ColumnResizing).isResizing;
 
 /**
  * Does the column have room to shrink?
  */
-export const canShrink = <DataType = unknown>(column: Column<DataType>) => meta.forColumn(column, ColumnResizing).canShrink;
+export const canShrink = <DataType = unknown>(column: Column<DataType>) => 
+  meta.forColumn(column, ColumnResizing).canShrink;
 
 /**
  * Does the column have a resize handle?

--- a/ember-headless-table/src/plugins/data-sorting/helpers.ts
+++ b/ember-headless-table/src/plugins/data-sorting/helpers.ts
@@ -40,11 +40,11 @@ export const sort = (column: Column) => meta.forTable(column.table, Sorting).han
 /**
  * Toggle a column between descending and not unsorted states
  */
-export const sortDescending = <DataType = unknown>(column: Column<DataType>) =>
+export const sortDescending = (column: Column) =>
   meta.forTable(column.table, Sorting).toggleDescending(column);
 
 /**
  * Toggle a column between ascending and not unsorted states
  */
-export const sortAscending = <DataType = unknown>(column: Column<DataType>) =>
+export const sortAscending = (column: Column) =>
   meta.forTable(column.table, Sorting).toggleAscending(column);

--- a/ember-headless-table/src/plugins/data-sorting/helpers.ts
+++ b/ember-headless-table/src/plugins/data-sorting/helpers.ts
@@ -6,31 +6,31 @@ import type { Column } from '[public-types]';
 /**
  * Query a specific column's current sort direction
  */
-export const sortDirection = <DataType = unknown>(column: Column<DataType>) => 
+export const sortDirection = <DataType = unknown>(column: Column<DataType>) =>
   meta.forColumn(column, Sorting).sortDirection;
 
 /**
  * Ask if a column is sortable
  */
-export const isSortable = <DataType = unknown>(column: Column<DataType>) => 
+export const isSortable = <DataType = unknown>(column: Column<DataType>) =>
   meta.forColumn(column, Sorting).isSortable;
 
 /**
  * Ask if a column is ascending
  */
-export const isAscending = <DataType = unknown>(column: Column<DataType>) => 
+export const isAscending = <DataType = unknown>(column: Column<DataType>) =>
   meta.forColumn(column, Sorting).isAscending;
 
 /**
  * Ask if a column is sorted descending
  */
-export const isDescending = <DataType = unknown>(column: Column<DataType>) => 
+export const isDescending = <DataType = unknown>(column: Column<DataType>) =>
   meta.forColumn(column, Sorting).isDescending;
 
 /**
  * Ask if a column is not sorted
  */
-export const isUnsorted = <DataType = unknown>(column: Column<DataType>) => 
+export const isUnsorted = <DataType = unknown>(column: Column<DataType>) =>
   meta.forColumn(column, Sorting).isUnsorted;
 
 /**

--- a/ember-headless-table/src/plugins/data-sorting/helpers.ts
+++ b/ember-headless-table/src/plugins/data-sorting/helpers.ts
@@ -35,7 +35,7 @@ export const isUnsorted = <DataType = unknown>(column: Column<DataType>) => meta
  *   Ascending => None => Descending
  *    ⬑ ---------- <= ---------- ↲
  */
-export const sort = <DataType = unknown>(column: Column<DataType>) => meta.forTable(column.table, Sorting).handleSort(column);
+export const sort = (column: Column) => meta.forTable(column.table, Sorting).handleSort(column);
 
 /**
  * Toggle a column between descending and not unsorted states

--- a/ember-headless-table/src/plugins/data-sorting/helpers.ts
+++ b/ember-headless-table/src/plugins/data-sorting/helpers.ts
@@ -6,27 +6,27 @@ import type { Column } from '[public-types]';
 /**
  * Query a specific column's current sort direction
  */
-export const sortDirection = (column: Column) => meta.forColumn(column, Sorting).sortDirection;
+export const sortDirection = <DataType = unknown>(column: Column<DataType>) => meta.forColumn(column, Sorting).sortDirection;
 
 /**
  * Ask if a column is sortable
  */
-export const isSortable = (column: Column) => meta.forColumn(column, Sorting).isSortable;
+export const isSortable = <DataType = unknown>(column: Column<DataType>) => meta.forColumn(column, Sorting).isSortable;
 
 /**
  * Ask if a column is ascending
  */
-export const isAscending = (column: Column) => meta.forColumn(column, Sorting).isAscending;
+export const isAscending = <DataType = unknown>(column: Column<DataType>) => meta.forColumn(column, Sorting).isAscending;
 
 /**
  * Ask if a column is sorted descending
  */
-export const isDescending = (column: Column) => meta.forColumn(column, Sorting).isDescending;
+export const isDescending = <DataType = unknown>(column: Column<DataType>) => meta.forColumn(column, Sorting).isDescending;
 
 /**
  * Ask if a column is not sorted
  */
-export const isUnsorted = (column: Column) => meta.forColumn(column, Sorting).isUnsorted;
+export const isUnsorted = <DataType = unknown>(column: Column<DataType>) => meta.forColumn(column, Sorting).isUnsorted;
 
 /**
  * Sort the specified column's data using a tri-toggle.
@@ -35,16 +35,16 @@ export const isUnsorted = (column: Column) => meta.forColumn(column, Sorting).is
  *   Ascending => None => Descending
  *    ⬑ ---------- <= ---------- ↲
  */
-export const sort = (column: Column) => meta.forTable(column.table, Sorting).handleSort(column);
+export const sort = <DataType = unknown>(column: Column<DataType>) => meta.forTable(column.table, Sorting).handleSort(column);
 
 /**
  * Toggle a column between descending and not unsorted states
  */
-export const sortDescending = (column: Column) =>
+export const sortDescending = <DataType = unknown>(column: Column<DataType>) =>
   meta.forTable(column.table, Sorting).toggleDescending(column);
 
 /**
  * Toggle a column between ascending and not unsorted states
  */
-export const sortAscending = (column: Column) =>
+export const sortAscending = <DataType = unknown>(column: Column<DataType>) =>
   meta.forTable(column.table, Sorting).toggleAscending(column);

--- a/ember-headless-table/src/plugins/data-sorting/helpers.ts
+++ b/ember-headless-table/src/plugins/data-sorting/helpers.ts
@@ -6,27 +6,32 @@ import type { Column } from '[public-types]';
 /**
  * Query a specific column's current sort direction
  */
-export const sortDirection = <DataType = unknown>(column: Column<DataType>) => meta.forColumn(column, Sorting).sortDirection;
+export const sortDirection = <DataType = unknown>(column: Column<DataType>) => 
+  meta.forColumn(column, Sorting).sortDirection;
 
 /**
  * Ask if a column is sortable
  */
-export const isSortable = <DataType = unknown>(column: Column<DataType>) => meta.forColumn(column, Sorting).isSortable;
+export const isSortable = <DataType = unknown>(column: Column<DataType>) => 
+  meta.forColumn(column, Sorting).isSortable;
 
 /**
  * Ask if a column is ascending
  */
-export const isAscending = <DataType = unknown>(column: Column<DataType>) => meta.forColumn(column, Sorting).isAscending;
+export const isAscending = <DataType = unknown>(column: Column<DataType>) => 
+  meta.forColumn(column, Sorting).isAscending;
 
 /**
  * Ask if a column is sorted descending
  */
-export const isDescending = <DataType = unknown>(column: Column<DataType>) => meta.forColumn(column, Sorting).isDescending;
+export const isDescending = <DataType = unknown>(column: Column<DataType>) => 
+  meta.forColumn(column, Sorting).isDescending;
 
 /**
  * Ask if a column is not sorted
  */
-export const isUnsorted = <DataType = unknown>(column: Column<DataType>) => meta.forColumn(column, Sorting).isUnsorted;
+export const isUnsorted = <DataType = unknown>(column: Column<DataType>) => 
+  meta.forColumn(column, Sorting).isUnsorted;
 
 /**
  * Sort the specified column's data using a tri-toggle.

--- a/ember-headless-table/src/plugins/data-sorting/plugin.ts
+++ b/ember-headless-table/src/plugins/data-sorting/plugin.ts
@@ -22,8 +22,8 @@ declare module 'ember-headless-table/plugins' {
 
 export interface Signature<DataType = unknown> {
   Meta: {
-    Column: ColumnMeta;
-    Table: TableMeta;
+    Column: ColumnMeta<DataType>;
+    Table: TableMeta<DataType>;
   };
   Options: {
     Plugin: Options<DataType>;
@@ -92,8 +92,8 @@ export class Sorting<DataType = unknown> extends BasePlugin<Signature<DataType>>
   };
 }
 
-export class ColumnMeta {
-  constructor(private column: Column) {}
+export class ColumnMeta<DataType = unknown> {
+  constructor(private column: Column<DataType>) {}
 
   @cached
   get options() {

--- a/ember-headless-table/src/plugins/data-sorting/plugin.ts
+++ b/ember-headless-table/src/plugins/data-sorting/plugin.ts
@@ -131,8 +131,8 @@ export class ColumnMeta {
   }
 }
 
-export class TableMeta {
-  constructor(private table: Table) {}
+export class TTableMeta<DataType = unknown> {
+  constructor(private table: Table<DataType>) {}
 
   @cached
   get options() {
@@ -152,7 +152,7 @@ export class TableMeta {
   }
 
   @action
-  handleSort(column: Column) {
+  handleSort(column: Column<DataType>) {
     let columnMeta = meta.forColumn(column, Sorting);
 
     if (!columnMeta.sortProperty) {
@@ -169,7 +169,7 @@ export class TableMeta {
   }
 
   @action
-  toggleAscending(column: Column) {
+  toggleAscending(column: Column<DataType>) {
     let columnMeta = meta.forColumn(column, Sorting);
 
     if (!columnMeta.sortProperty) {

--- a/ember-headless-table/src/plugins/data-sorting/plugin.ts
+++ b/ember-headless-table/src/plugins/data-sorting/plugin.ts
@@ -131,7 +131,7 @@ export class ColumnMeta {
   }
 }
 
-export class TTableMeta<DataType = unknown> {
+export class TableMeta<DataType = unknown> {
   constructor(private table: Table<DataType>) {}
 
   @cached

--- a/ember-headless-table/src/plugins/metadata/helpers.ts
+++ b/ember-headless-table/src/plugins/metadata/helpers.ts
@@ -3,10 +3,10 @@ import { Metadata } from './plugin';
 
 import type { Column, Table } from '[public-types]';
 
-export const forColumn = (column: Column<any>, key: string) => {
+export const forColumn = <DataType = unknown>(column: Column<DataType>, key: string) => {
   return options.forColumn(column, Metadata)[key];
 };
 
-export const forTable = (table: Table<any>, key: string) => {
+export const forTable = <DataType = unknown>(table: Table<DataType>, key: string) => {
   return options.forTable(table, Metadata)[key];
 };


### PR DESCRIPTION
Proposed fix for #247 for Resize-handle and data-sorting