### PR TITLE
Update ember-resources from v5 to v7

### DIFF
--- a/.changeset/clever-baboons-type.md
+++ b/.changeset/clever-baboons-type.md
@@ -1,0 +1,5 @@
+---
+'ember-headless-table': minor
+---
+
+Upgrade internal dependencies entry: ember-resources from v5 to v7

--- a/ember-headless-table/package.json
+++ b/ember-headless-table/package.json
@@ -95,9 +95,11 @@
     "@embroider/addon-shim": "^1.0.0",
     "@embroider/macros": "1.10.0",
     "ember-modifier": "^3.2.7",
-    "ember-resources": "^5.4.0",
+    "ember-resources": "^7.0.2",
     "ember-tracked-storage-polyfill": "^1.0.0",
-    "tracked-built-ins": "^3.1.0"
+    "tracked-built-ins": "^3.1.0",
+    "reactiveweb": "^1.3.0",
+    "ember-modify-based-class-resource": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.17.0",

--- a/ember-headless-table/src/-private/table.ts
+++ b/ember-headless-table/src/-private/table.ts
@@ -6,8 +6,8 @@ import { guidFor } from '@ember/object/internals';
 
 import { isDevelopingApp, macroCondition } from '@embroider/macros';
 import { modifier } from 'ember-modifier';
-import { Resource } from 'ember-resources/core';
-import { map } from 'ember-resources/util/map';
+import { Resource } from 'ember-modify-based-class-resource';
+import { map } from 'reactiveweb/map';
 
 import { normalizePluginsConfig, verifyPlugins } from '../plugins/-private/utils';
 import { Column } from './column';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '6.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 overrides:
@@ -94,7 +94,7 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.22.5
-        version: 7.22.5(supports-color@8.1.1)
+        version: 7.22.5
       '@babel/eslint-parser':
         specifier: ^7.11.0
         version: 7.21.3(@babel/core@7.22.5)(eslint@7.32.0)
@@ -286,7 +286,7 @@ importers:
         version: 6.2.0(@ember/test-helpers@2.9.4)(ember-source@4.12.0)(qunit@2.19.4)(webpack@5.83.1)
       ember-resolver:
         specifier: ^10.0.0
-        version: 10.0.0(@ember/string@3.1.1)(ember-source@4.12.0)
+        version: 10.0.0(ember-source@4.12.0)
       ember-source:
         specifier: ~4.12.0
         version: 4.12.0(@babel/core@7.22.5)(@glimmer/component@1.1.2)(webpack@5.83.1)
@@ -368,12 +368,18 @@ importers:
       ember-modifier:
         specifier: ^3.2.7
         version: 3.2.7(@babel/core@7.21.4)
+      ember-modify-based-class-resource:
+        specifier: ^1.1.0
+        version: 1.1.0(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(ember-resources@7.0.2)(ember-source@4.10.0)
       ember-resources:
-        specifier: ^5.4.0
-        version: 5.6.4(@ember/test-waiters@3.0.2)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.10.0)
+        specifier: ^7.0.2
+        version: 7.0.2(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.10.0)
       ember-tracked-storage-polyfill:
         specifier: ^1.0.0
         version: 1.0.0
+      reactiveweb:
+        specifier: ^1.3.0
+        version: 1.3.0(@babel/core@7.21.4)(@ember/test-waiters@3.0.2)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.10.0)
       tracked-built-ins:
         specifier: ^3.1.0
         version: 3.1.1
@@ -521,7 +527,7 @@ importers:
         version: 2.0.0
       debug:
         specifier: ^4.3.4
-        version: 4.3.4(supports-color@8.1.1)
+        version: 4.3.4
       fs-extra:
         specifier: ^11.1.0
         version: 11.1.0
@@ -851,10 +857,32 @@ packages:
       '@babel/traverse': 7.21.4
       '@babel/types': 7.21.4
       convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/core@7.22.5:
+    resolution: {integrity: sha512-SBuTAjg91A3eKOvD+bPEz3LlhHZRNu1nFOVts9lzDJTXshHTjII0BAtDS3Y2DAkdZdDKWVZGVwkDfc4Clxn1dg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@babel/code-frame': 7.22.5
+      '@babel/generator': 7.22.5
+      '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.22.5)
+      '@babel/helper-module-transforms': 7.22.5
+      '@babel/helpers': 7.22.5
+      '@babel/parser': 7.22.5
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.5
+      '@babel/types': 7.22.5
+      convert-source-map: 1.9.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -901,7 +929,7 @@ packages:
       '@babel/core': '>=7.11.0'
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
       eslint: 7.32.0
       eslint-visitor-keys: 2.1.0
@@ -979,7 +1007,7 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/compat-data': 7.23.5
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-validator-option': 7.23.5
       browserslist: 4.21.5
       lru-cache: 5.1.1
@@ -1020,7 +1048,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-function-name': 7.22.5
@@ -1055,7 +1083,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
@@ -1072,7 +1100,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-function-name': 7.24.7
@@ -1091,7 +1119,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-annotate-as-pure': 7.24.7
       regexpu-core: 5.3.2
       semver: 6.3.1
@@ -1101,9 +1129,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.22.5)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.24.7
       debug: 4.3.5
       lodash.debounce: 4.0.8
       resolve: 1.22.8
@@ -1116,10 +1144,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.24.7
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -1221,7 +1249,22 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.5
       '@babel/helper-validator-identifier': 7.22.20
       '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.5(supports-color@8.1.1)
+      '@babel/traverse': 7.22.5
+      '@babel/types': 7.22.5
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/helper-module-transforms@7.22.5:
+    resolution: {integrity: sha512-+hGKDt/Ze8GFExiVHno/2dvG5IdstpzCq0y4Qc9OJ25D4q3pKfiIP/4Vp3/JvhDkLKsDK2api3q3fpIgiIF5bw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.5
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.5
       '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
@@ -1261,7 +1304,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
@@ -1304,7 +1347,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-wrap-function': 7.22.20
@@ -1317,7 +1360,7 @@ packages:
       '@babel/helper-member-expression-to-functions': 7.21.0
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.5(supports-color@8.1.1)
+      '@babel/traverse': 7.22.5
       '@babel/types': 7.23.9
     transitivePeerDependencies:
       - supports-color
@@ -1339,7 +1382,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
@@ -1350,7 +1393,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-member-expression-to-functions': 7.24.7
       '@babel/helper-optimise-call-expression': 7.24.7
@@ -1458,7 +1501,17 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.5(supports-color@8.1.1)
+      '@babel/traverse': 7.22.5
+      '@babel/types': 7.22.5
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/helpers@7.22.5:
+    resolution: {integrity: sha512-pSXRmfE1vzcUIDFQcSGA5Mr+GxBV9oiRKDuDxXvWQQBCh8HoIjs/2DlDB7H8smac1IVrB9/xdXj2N3Wol9Cr+Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.5
       '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
@@ -1541,8 +1594,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-iRkKcCqb7iGnq9+3G6rZ+Ciz5VywC4XNRHe57lKM+jOeYAoR0lVqdeeDRfh0tQcTfw/+vBhHn926FmQhLtlFLQ==}
@@ -1550,7 +1603,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.20.7(@babel/core@7.22.5):
@@ -1559,8 +1612,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.22.5)
     transitivePeerDependencies:
@@ -1572,7 +1625,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
       '@babel/plugin-transform-optional-chaining': 7.23.4(@babel/core@7.22.5)
@@ -1585,7 +1638,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
 
@@ -1595,9 +1648,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.22.5)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.22.5)
 
@@ -1620,7 +1673,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.21.4(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
@@ -1632,9 +1685,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.22.5)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.22.5)
     transitivePeerDependencies:
       - supports-color
@@ -1661,7 +1714,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.21.4(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-replace-supers': 7.20.7
@@ -1676,7 +1729,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-decorators': 7.23.3(@babel/core@7.22.5)
@@ -1689,8 +1742,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.22.5)
 
   /@babel/plugin-proposal-export-namespace-from@7.18.9(@babel/core@7.22.5):
@@ -1699,8 +1752,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.22.5)
 
   /@babel/plugin-proposal-json-strings@7.18.6(@babel/core@7.22.5):
@@ -1709,8 +1762,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.22.5)
 
   /@babel/plugin-proposal-logical-assignment-operators@7.20.7(@babel/core@7.22.5):
@@ -1719,8 +1772,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.22.5)
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.22.5):
@@ -1729,8 +1782,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.22.5)
 
   /@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.22.5):
@@ -1739,8 +1792,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.22.5)
 
   /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.22.5):
@@ -1750,9 +1803,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.22.5
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.22.5)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.22.5)
       '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.22.5)
 
@@ -1762,8 +1815,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.22.5)
 
   /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.22.5):
@@ -1772,8 +1825,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.5)
     transitivePeerDependencies:
@@ -1798,7 +1851,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.21.4(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
@@ -1810,7 +1863,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.22.5
@@ -1822,7 +1875,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
 
   /@babel/plugin-proposal-private-property-in-object@7.21.11(@babel/core@7.22.5):
     resolution: {integrity: sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==}
@@ -1831,7 +1884,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.24.7
@@ -1845,25 +1898,25 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.22.5)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.22.5):
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.22.5):
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
@@ -1871,8 +1924,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-decorators@7.21.0(@babel/core@7.21.4):
     resolution: {integrity: sha512-tIoPpGBR8UuM4++ccWN3gifhVvQu7ZizuR1fklhRJrd5ewgbkUS+0KVFeWWxELtn18NTLoW32XV7zyOgIAiz+w==}
@@ -1890,8 +1943,18 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.20.2
+
+  /@babel/plugin-syntax-decorators@7.23.3(@babel/core@7.21.4):
+    resolution: {integrity: sha512-cf7Niq4/+/juY67E0PbgH0TDhLQ5J7zS8C/Q5FFx+DWyrRa9sUQdTXkjqKu8zGvuqr7vw1muKiukseihU+PJDA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.4
+      '@babel/helper-plugin-utils': 7.24.7
+    dev: false
 
   /@babel/plugin-syntax-decorators@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-cf7Niq4/+/juY67E0PbgH0TDhLQ5J7zS8C/Q5FFx+DWyrRa9sUQdTXkjqKu8zGvuqr7vw1muKiukseihU+PJDA==}
@@ -1899,15 +1962,15 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.22.5):
@@ -1915,8 +1978,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-import-assertions@7.20.0(@babel/core@7.22.5):
     resolution: {integrity: sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==}
@@ -1924,8 +1987,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-import-assertions@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-lPgDSU+SJLK3xmFDTV2ZRQAiM7UuUjGidwBywFavObCiZc1BeAAcMtHJKUya92hPHO+at63JJPLygilZard8jw==}
@@ -1933,7 +1996,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-import-attributes@7.23.3(@babel/core@7.22.5):
@@ -1942,7 +2005,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.22.5):
@@ -1950,7 +2013,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.22.5):
@@ -1958,8 +2021,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-jsx@7.21.4(@babel/core@7.21.4):
     resolution: {integrity: sha512-5hewiLct5OKyh6PLKEYaFclcqtIgCb6bmELouxjF6up5q3Sov7rOayW4RwhbaBL0dit8rA80GNfY+UuDp2mBbQ==}
@@ -1976,48 +2039,48 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.22.5):
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
@@ -2025,8 +2088,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
@@ -2034,8 +2097,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-typescript@7.21.4(@babel/core@7.21.4):
     resolution: {integrity: sha512-xz0D39NvhQn4t4RNsHmDnnsaQizIlUkdtYvLs8La1BlfjQ6JEwxkJGeqJMW2tAXx+q6H+WFuUTXNdYVpEya0YA==}
@@ -2053,7 +2116,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-typescript@7.23.3(@babel/core@7.21.4):
@@ -2063,7 +2126,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-typescript@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-9EiNjVJOMwCO+43TqoTrgQ8jMwcAd0sWyXi9RPfIsLTj4R2MADDDQXELhffaUx/uJv2AYcxBgPwH6j4TIA4ytQ==}
@@ -2071,8 +2134,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA==}
@@ -2080,7 +2143,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.22.5):
@@ -2089,7 +2152,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.24.7
 
@@ -2099,8 +2162,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-arrow-functions@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-NzQcQrzaQPkaEwoTm4Mhyl8jI1huEL/WWIEvudjTCMJ9aBZNpsJbMASx7EQECtQQPS/DcnFpo0FIh3LvEO9cxQ==}
@@ -2108,7 +2171,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-async-generator-functions@7.23.9(@babel/core@7.22.5):
@@ -2117,7 +2180,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.22.5)
@@ -2129,9 +2192,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-module-imports': 7.22.15
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.22.5)
 
   /@babel/plugin-transform-async-to-generator@7.23.3(@babel/core@7.22.5):
@@ -2140,7 +2203,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.22.5)
@@ -2151,8 +2214,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-block-scoped-functions@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-vI+0sIaPIO6CNuM9Kk5VmXcMVRiOpDh7w2zZt9GXzmE/9KD70CUEVhvPR/etAeNK/FAEkhxQtXOzVF3EuRL41A==}
@@ -2160,7 +2223,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-block-scoping@7.21.0(@babel/core@7.21.4):
@@ -2178,7 +2241,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-block-scoping@7.23.4(@babel/core@7.22.5):
@@ -2187,7 +2250,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-class-properties@7.23.3(@babel/core@7.22.5):
@@ -2196,7 +2259,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.24.7
     transitivePeerDependencies:
@@ -2208,7 +2271,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.22.5)
@@ -2221,13 +2284,13 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.22.5)
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-optimise-call-expression': 7.24.7
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-replace-supers': 7.24.7(@babel/core@7.22.5)
       '@babel/helper-split-export-declaration': 7.24.7
       globals: 11.12.0
@@ -2240,7 +2303,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-environment-visitor': 7.24.7
@@ -2258,8 +2321,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/template': 7.24.7
 
   /@babel/plugin-transform-computed-properties@7.23.3(@babel/core@7.22.5):
@@ -2268,7 +2331,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/template': 7.24.7
 
@@ -2278,8 +2341,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-destructuring@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-n225npDqjDIr967cMScVKHXJs7rout1q+tt50inyBCPkyZ8KxeI6d+GIbSBTT/w/9WdlWDOej3V9HE5Lgk57gw==}
@@ -2287,7 +2350,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-dotall-regex@7.18.6(@babel/core@7.22.5):
@@ -2296,9 +2359,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.22.5)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-dotall-regex@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-vgnFYDHAKzFaTVp+mneDsIEbnJ2Np/9ng9iviHw3P/KVcgONxpNULEW/51Z/BaFojG2GI2GwwXck5uV1+1NOYQ==}
@@ -2306,7 +2369,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.24.7
 
@@ -2316,8 +2379,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-duplicate-keys@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-RrqQ+BQmU3Oyav3J+7/myfvRCq7Tbz+kKLLshUmMwNlDHExbGL7ARhajvoBJEvc+fCguPPu887N+3RRXBVKZUA==}
@@ -2325,7 +2388,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-dynamic-import@7.23.4(@babel/core@7.22.5):
@@ -2334,7 +2397,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.22.5)
 
@@ -2344,9 +2407,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-exponentiation-operator@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-5fhCsl1odX96u7ILKHBj4/Y8vipoqwsJMh4csSA8qFfxrZDEA4Ssku2DyNvMJSmZNOEBT750LfFPbtrnTP90BQ==}
@@ -2354,7 +2417,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
       '@babel/helper-plugin-utils': 7.24.7
 
@@ -2364,7 +2427,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.22.5)
 
@@ -2374,8 +2437,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-for-of@7.23.6(@babel/core@7.22.5):
     resolution: {integrity: sha512-aYH4ytZ0qSuBbpfhuofbg/e96oQ7U2w1Aw/UQmKT+1l39uEhUPoFS3fHevDc1G0OvewyDudfMKY1OulczHzWIw==}
@@ -2383,7 +2446,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
     transitivePeerDependencies:
@@ -2395,10 +2458,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.22.5)
       '@babel/helper-function-name': 7.24.7
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-function-name@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-I1QXp1LxIvt8yLaib49dRW5Okt7Q4oaxao6tFVKS/anCdEOMtYwWVKoiOA1p34GOWIZjUK0E+zCp7+l1pfQyiw==}
@@ -2406,7 +2469,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
@@ -2417,7 +2480,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.22.5)
 
@@ -2427,8 +2490,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-literals@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-wZ0PIXRxnwZvl9AYpqNUxpZ5BiTGrYt7kueGQ+N5FiQ7RCOD4cm8iShd6S6ggfVIWaJf2EMk8eRzAh52RfP4rQ==}
@@ -2436,7 +2499,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-logical-assignment-operators@7.23.4(@babel/core@7.22.5):
@@ -2445,7 +2508,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.22.5)
 
@@ -2455,8 +2518,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-member-expression-literals@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-sC3LdDBDi5x96LA+Ytekz2ZPk8i/Ck+DEuDbRAll5rknJ5XRTSaPKEYwomLcs1AA8wg9b3KjIQRsnApj+q51Ag==}
@@ -2464,7 +2527,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-modules-amd@7.20.11(@babel/core@7.22.5):
@@ -2473,9 +2536,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.22.5)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-modules-amd@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-vJYQGxeKM4t8hYCKVBlZX/gtIY2I7mRGFNcm85sgXGMTBcoV3QdVtdpbcWEbzbfUIUZKwvgFT82mRvaQIebZzw==}
@@ -2483,7 +2546,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.24.7
 
@@ -2505,7 +2568,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-simple-access': 7.22.5
@@ -2516,7 +2579,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-simple-access': 7.22.5
@@ -2527,10 +2590,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-hoist-variables': 7.24.7
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.22.5)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-validator-identifier': 7.24.7
 
   /@babel/plugin-transform-modules-systemjs@7.23.9(@babel/core@7.22.5):
@@ -2539,7 +2602,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-hoist-variables': 7.24.7
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.24.7
@@ -2551,9 +2614,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.22.5)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-modules-umd@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-zHsy9iXX2nIsCBFPud3jKn1IRPWg3Ing1qOZgeKV39m1ZgIdpJqvlWVeiHBZC6ITRG0MfskhYe9cLgntfSFPIg==}
@@ -2561,7 +2624,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.24.7
 
@@ -2571,9 +2634,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.22.5)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==}
@@ -2581,7 +2644,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.24.7
 
@@ -2591,8 +2654,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-new-target@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-YJ3xKqtJMAT5/TIZnpAR3I+K+WaDowYbN3xyxI8zxx/Gsypwf9B9h0VB+1Nh6ACAAPRS5NSRje0uVv5i79HYGQ==}
@@ -2600,7 +2663,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-nullish-coalescing-operator@7.23.4(@babel/core@7.22.5):
@@ -2609,7 +2672,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.22.5)
 
@@ -2619,7 +2682,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.22.5)
 
@@ -2639,7 +2702,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.23.5
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.22.5)
@@ -2651,8 +2714,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-replace-supers': 7.24.7(@babel/core@7.22.5)
     transitivePeerDependencies:
       - supports-color
@@ -2663,7 +2726,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-replace-supers': 7.24.7(@babel/core@7.22.5)
     transitivePeerDependencies:
@@ -2675,7 +2738,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.22.5)
 
@@ -2685,7 +2748,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.5)
@@ -2698,8 +2761,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-parameters@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-09lMt6UsUb3/34BbECKVbVwrT9bO6lILWln237z7sLaWnMsTi7Yc9fhX5DLpkJzAGfaReXI22wP41SZmnAA3Vw==}
@@ -2707,7 +2770,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-private-methods@7.23.3(@babel/core@7.22.5):
@@ -2716,7 +2779,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.24.7
     transitivePeerDependencies:
@@ -2728,7 +2791,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.24.7
@@ -2742,8 +2805,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-property-literals@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-jR3Jn3y7cZp4oEWPFAlRsSWjxKe4PZILGBSd4nis1TsC5qeSpb+nrtihJuDhNI7QHiVbUaiXa0X2RZY3/TI6Nw==}
@@ -2751,7 +2814,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-regenerator@7.20.5(@babel/core@7.22.5):
@@ -2760,8 +2823,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
       regenerator-transform: 0.15.2
 
   /@babel/plugin-transform-regenerator@7.23.3(@babel/core@7.22.5):
@@ -2770,7 +2833,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
       regenerator-transform: 0.15.2
 
@@ -2780,8 +2843,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-reserved-words@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-QnNTazY54YqgGxwIexMZva9gqbPa15t/x9VS+0fsEFWplwVpXYZivtgl43Z1vMpc1bdPP2PP8siFeVcnFvA3Cg==}
@@ -2789,7 +2852,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-runtime@7.21.4(@babel/core@7.22.5):
@@ -2798,7 +2861,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.20.2
       babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.22.5)
@@ -2814,7 +2877,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.24.7
       babel-plugin-polyfill-corejs2: 0.4.8(@babel/core@7.22.5)
@@ -2830,8 +2893,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-shorthand-properties@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-ED2fgqZLmexWiN+YNFX26fx4gh5qHDhn1O2gvEhreLW2iI63Sqm4llRLCXALKrCnbN4Jy0VcMQZl/SAzqug/jg==}
@@ -2839,7 +2902,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-spread@7.20.7(@babel/core@7.22.5):
@@ -2848,8 +2911,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
     transitivePeerDependencies:
       - supports-color
@@ -2860,7 +2923,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
     transitivePeerDependencies:
@@ -2872,8 +2935,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-sticky-regex@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-HZOyN9g+rtvnOU3Yh7kSxXrKbzgrm5X4GncPY1QOquu7epga5MxKHVpYu2hvQnry/H+JjckSYRb93iNfsioAGg==}
@@ -2881,7 +2944,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.22.5):
@@ -2890,8 +2953,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-template-literals@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-Flok06AYNp7GV2oJPZZcP9vZdszev6vPBkHLwxwSpaIqx75wn6mUd3UFWsSsA0l8nXAKkyCmL/sR02m8RYGeHg==}
@@ -2899,7 +2962,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-typeof-symbol@7.18.9(@babel/core@7.22.5):
@@ -2908,8 +2971,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-typeof-symbol@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-4t15ViVnaFdrPC74be1gXBSMzXk3B4Us9lP7uLRQHTFpV5Dvt33pn+2MyyNxmN3VTTm3oTrZVMUmuw3oBnQ2oQ==}
@@ -2917,7 +2980,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-typescript@7.21.3(@babel/core@7.21.4):
@@ -2941,7 +3004,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-create-class-features-plugin': 7.21.4(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.20.2
@@ -2955,7 +3018,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.24.7
@@ -2969,7 +3032,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.21.4)
     dev: true
 
@@ -2978,8 +3041,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.22.5)
     dev: true
 
@@ -2990,7 +3053,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.4
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.21.4)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.21.4)
 
   /@babel/plugin-transform-typescript@7.5.5(@babel/core@7.22.5):
@@ -2998,9 +3061,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.22.5)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.22.5)
 
   /@babel/plugin-transform-typescript@7.8.7(@babel/core@7.22.5):
@@ -3008,7 +3071,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.24.7(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.22.5)
@@ -3022,8 +3085,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-unicode-escapes@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-OMCUx/bU6ChE3r4+ZdylEqAjaQgHAgipgW8nsCfu5pGqDcFytVd91AwRvUJSBZDz0exPGgnjoqhgRYLRjFZc9Q==}
@@ -3031,7 +3094,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-unicode-property-regex@7.23.3(@babel/core@7.22.5):
@@ -3040,7 +3103,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.24.7
 
@@ -3050,9 +3113,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.22.5)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-unicode-regex@7.23.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-wMHpNA4x2cIA32b/ci3AfwNgheiva2W0WUKWTK7vBHBhDKfPsc5cFGNWm69WBqpwd86u1qwZ9PWevKqm1A3yAw==}
@@ -3060,7 +3123,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.24.7
 
@@ -3070,7 +3133,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.24.7
 
@@ -3088,7 +3151,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.22.5
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-validator-option': 7.22.5
@@ -3173,7 +3236,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.23.5
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/helper-validator-option': 7.23.5
@@ -3261,8 +3324,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.22.5)
       '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.22.5)
       '@babel/types': 7.23.9
@@ -3273,7 +3336,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.24.7
       '@babel/types': 7.24.7
       esutils: 2.0.3
@@ -3357,7 +3420,24 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.5
       '@babel/parser': 7.22.5
       '@babel/types': 7.23.9
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/traverse@7.22.5:
+    resolution: {integrity: sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.22.5
+      '@babel/generator': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.5
+      '@babel/parser': 7.22.5
+      '@babel/types': 7.22.5
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -3736,7 +3816,7 @@ packages:
     resolution: {integrity: sha512-QQ3qLzXVJIOiULe8ebccX8RvtftDYl0DItYRe1R5qF7Q0JInF+JkX2XcTe6sy14i1sZXDvim+JnlpsKdjDC+Gg==}
     engines: {node: '>= 12.*'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       fast-glob: 3.2.12
       git-repo-info: 2.1.1
       github-slugger: 1.5.0
@@ -3772,7 +3852,7 @@ packages:
       broccoli-plugin: 4.0.7
       broccoli-source: 3.0.1
       calculate-cache-key-for-tree: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       ember-cli-babel: 8.2.0(@babel/core@7.22.5)
       ember-cli-htmlbars: 6.3.0
       ember-cli-typescript: 4.2.1
@@ -3815,15 +3895,6 @@ packages:
       - supports-color
     dev: false
 
-  /@ember/string@3.1.0:
-    resolution: {integrity: sha512-kIV8E/OH+QdbUJiMIs2BvzxbVbRGiCjf/cgEhlXEaIMISnkwZdCB/KcywrD21ZApG1A0U8IUSrNox8JojK7ceA==}
-    engines: {node: 12.* || 14.* || >= 16}
-    dependencies:
-      ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@ember/string@3.1.1:
     resolution: {integrity: sha512-UbXJ+k3QOrYN4SRPHgXCqYIJ+yWWUg1+vr0H4DhdQPTy8LJfyqwZ2tc5uqpSSnEXE+/1KopHBE5J8GDagAg5cg==}
     engines: {node: 12.* || 14.* || >= 16}
@@ -3831,7 +3902,7 @@ packages:
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - supports-color
-    dev: true
+    dev: false
 
   /@ember/test-helpers@2.9.3(@babel/core@7.21.4)(@glint/template@1.0.2)(ember-source@3.28.11):
     resolution: {integrity: sha512-ejVg4Dj+G/6zyLvQsYOvmGiOLU6AS94tY4ClaO1E2oVvjjtVJIRmVLFN61I+DuyBg9hS3cFoPjQRTZB9MRIbxQ==}
@@ -4013,7 +4084,7 @@ packages:
       '@embroider/core': ^2.0.0
     dependencies:
       '@babel/code-frame': 7.21.4
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.22.5)
       '@babel/preset-env': 7.21.4(@babel/core@7.22.5)
       '@babel/traverse': 7.21.4
@@ -4035,10 +4106,10 @@ packages:
       broccoli-plugin: 4.0.7
       broccoli-source: 3.0.1
       chalk: 4.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       fs-extra: 9.1.0
       fs-tree-diff: 2.0.1
-      jsdom: 16.7.0(supports-color@8.1.1)
+      jsdom: 16.7.0
       lodash: 4.17.21
       pkg-up: 3.1.0
       resolve: 1.22.2
@@ -4060,7 +4131,7 @@ packages:
     resolution: {integrity: sha512-N4rz+r8WjHYmwprvBYC0iUT4EWNpdDjF7JLl8PEYlWbhXDEJL+Ma/aP78S7spMhIpJX9SHK7nbgNxmZAqAe34A==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/parser': 7.21.4
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.22.5)
       '@babel/plugin-transform-runtime': 7.21.4(@babel/core@7.22.5)
@@ -4075,7 +4146,7 @@ packages:
       broccoli-persistent-filter: 3.1.3
       broccoli-plugin: 4.0.7
       broccoli-source: 3.0.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       escape-string-regexp: 4.0.0
       fast-sourcemap-concat: 1.4.0
       filesize: 5.0.3
@@ -4083,7 +4154,7 @@ packages:
       fs-tree-diff: 2.0.1
       handlebars: 4.7.7
       js-string-escape: 1.0.1
-      jsdom: 16.7.0(supports-color@8.1.1)
+      jsdom: 16.7.0
       lodash: 4.17.21
       resolve: 1.22.2
       resolve-package-path: 4.0.3
@@ -4172,6 +4243,7 @@ packages:
       typescript-memoize: 1.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@embroider/test-setup@2.1.1:
     resolution: {integrity: sha512-t81a2z2OEFAOZVbV7wkgiDuCyZ3ajD7J7J+keaTfNSRiXoQgeFFASEECYq1TCsH8m/R+xHMRiY59apF2FIeFhw==}
@@ -4280,7 +4352,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       espree: 7.3.1
       globals: 13.20.0
       ignore: 4.0.6
@@ -4591,7 +4663,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -4673,7 +4745,7 @@ packages:
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.24.7
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -4800,7 +4872,7 @@ packages:
       prettier:
         optional: true
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/eslint-parser': 7.21.3(@babel/core@7.22.5)(eslint@7.32.0)
       cosmiconfig: 8.1.3
       eslint: 7.32.0
@@ -5135,7 +5207,7 @@ packages:
     resolution: {integrity: sha512-G6kbLaS3ke4QspHkgLlGY0t1v0G22hGavyphezZucj7LLk1N+r11w913CYkBg3cJsJD+TG2Wo4eVbgRcotvuvQ==}
     dependencies:
       '@types/ember': 4.0.3(@babel/core@7.21.4)
-      '@types/ember__object': 4.0.5(@babel/core@7.21.4)
+      '@types/ember__object': 4.0.5
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -5153,7 +5225,7 @@ packages:
     resolution: {integrity: sha512-mxPme8PexMrv/GPUOE9uPzxjVhHhrznGG4HRUsZNvrHwBbvVwJ/ClgDxz1NZeaYrKhAstQ6QjorssoEXaoer+A==}
     dependencies:
       '@types/ember': 4.0.3(@babel/core@7.21.4)
-      '@types/ember__object': 4.0.5(@babel/core@7.21.4)
+      '@types/ember__object': 4.0.5
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -5166,6 +5238,11 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+
+  /@types/ember__controller@4.0.4:
+    resolution: {integrity: sha512-+f0knTIJJkRX5xijeSI/n4FvLfhMFFxIxODyFFFFB483EryYuts3QzpTwU5D66WQ5rAbZvpPRXRMPTTCNJoUhg==}
+    dependencies:
+      '@types/ember__object': 4.0.5
 
   /@types/ember__controller@4.0.4(@babel/core@7.21.4):
     resolution: {integrity: sha512-+f0knTIJJkRX5xijeSI/n4FvLfhMFFxIxODyFFFFB483EryYuts3QzpTwU5D66WQ5rAbZvpPRXRMPTTCNJoUhg==}
@@ -5226,6 +5303,12 @@ packages:
   /@types/ember__error@4.0.2:
     resolution: {integrity: sha512-0KVIvGrpyYzO4dmBm04ovJ/Fd7DjiXABxkKX42O8U01OL6O+Q+m3euQuJbB5wkYVANnvBHpcHlxRUI2y9KmzYg==}
 
+  /@types/ember__object@4.0.5:
+    resolution: {integrity: sha512-gXrywWBwoW7J9y9yJqoZ0m1qtiyMdrEi29cJdF1xI2qOnMqaZeuSCMYaPQMsyq52/YnVIG2EnGzo6eUD57J4Nw==}
+    dependencies:
+      '@types/ember': 4.0.3(@babel/core@7.21.4)
+      '@types/rsvp': 4.0.4
+
   /@types/ember__object@4.0.5(@babel/core@7.21.4):
     resolution: {integrity: sha512-gXrywWBwoW7J9y9yJqoZ0m1qtiyMdrEi29cJdF1xI2qOnMqaZeuSCMYaPQMsyq52/YnVIG2EnGzo6eUD57J4Nw==}
     dependencies:
@@ -5254,9 +5337,9 @@ packages:
     resolution: {integrity: sha512-zxPS43JP8/dEmNrSucN5KzTvOm+JUrbFGWsJ1m5a395FwxYbpgs7JujV0JWl+eVhnCh/PmsNcCdJT16+jouktQ==}
     dependencies:
       '@types/ember': 4.0.3(@babel/core@7.21.4)
-      '@types/ember__controller': 4.0.4(@babel/core@7.21.4)
-      '@types/ember__object': 4.0.5(@babel/core@7.21.4)
-      '@types/ember__service': 4.0.2(@babel/core@7.21.4)
+      '@types/ember__controller': 4.0.4
+      '@types/ember__object': 4.0.5
+      '@types/ember__service': 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -5265,9 +5348,9 @@ packages:
     resolution: {integrity: sha512-zxPS43JP8/dEmNrSucN5KzTvOm+JUrbFGWsJ1m5a395FwxYbpgs7JujV0JWl+eVhnCh/PmsNcCdJT16+jouktQ==}
     dependencies:
       '@types/ember': 4.0.3(@babel/core@7.22.5)
-      '@types/ember__controller': 4.0.4(@babel/core@7.21.4)
-      '@types/ember__object': 4.0.5(@babel/core@7.21.4)
-      '@types/ember__service': 4.0.2(@babel/core@7.21.4)
+      '@types/ember__controller': 4.0.4
+      '@types/ember__object': 4.0.5
+      '@types/ember__service': 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -5287,6 +5370,11 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+
+  /@types/ember__service@4.0.2:
+    resolution: {integrity: sha512-7SCTMEexxOdkpkgdyf1QLFQJhoAq6aqP6dPH9fcG8N5mTMvZGLMNIKGG9bldiq3NzHS9Pxogu3qgo5yMfc2+jA==}
+    dependencies:
+      '@types/ember__object': 4.0.5
 
   /@types/ember__service@4.0.2(@babel/core@7.21.4):
     resolution: {integrity: sha512-7SCTMEexxOdkpkgdyf1QLFQJhoAq6aqP6dPH9fcG8N5mTMvZGLMNIKGG9bldiq3NzHS9Pxogu3qgo5yMfc2+jA==}
@@ -5890,6 +5978,14 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  /agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+    dependencies:
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+
   /agent-base@6.0.2(supports-color@8.1.1):
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -5897,6 +5993,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
@@ -5906,10 +6003,8 @@ packages:
       indent-string: 4.0.0
     dev: true
 
-  /ajv-formats@2.1.1(ajv@8.12.0):
+  /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -6185,7 +6280,7 @@ packages:
   /async-disk-cache@1.3.5:
     resolution: {integrity: sha512-VZpqfR0R7CEOJZ/0FOTgWq70lCrZyS1rkI8PXugDUkTKyyAUgZ2zQ09gLhMkEn+wN8LYeUTPxZdXtlX/kmbXKQ==}
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       heimdalljs: 0.2.6
       istextorbinary: 2.1.0
       mkdirp: 0.5.6
@@ -6199,7 +6294,7 @@ packages:
     resolution: {integrity: sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==}
     engines: {node: 8.* || >= 10.*}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       heimdalljs: 0.2.6
       istextorbinary: 2.6.0
       mkdirp: 0.5.6
@@ -6213,7 +6308,7 @@ packages:
     resolution: {integrity: sha512-xi0aQ1rrjPWYmqbwr18rrSKbSaXIeIwSd1J4KAgVfkq8utNbdZoht7GfvfY6swFUAMJ9obkc4WPJmtGwl+B8dw==}
     dependencies:
       async: 2.6.4
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
     transitivePeerDependencies:
       - supports-color
 
@@ -6275,7 +6370,7 @@ packages:
     dependencies:
       '@babel/code-frame': 7.24.2
       '@babel/parser': 7.22.5
-      '@babel/traverse': 7.22.5(supports-color@8.1.1)
+      '@babel/traverse': 7.22.5
       '@babel/types': 7.23.9
       eslint: 7.32.0
       eslint-visitor-keys: 1.3.0
@@ -6401,13 +6496,25 @@ packages:
     resolution: {integrity: sha512-PPzUT17eAI18zn6ek1R3sB4Krc/MbnmT1MkZQFmyhjoaEGBVwNABhfVU9+EKcDSKrrOm9OIpGhjxukx1GCiy1g==}
     engines: {node: '>= 12.*'}
 
-  /babel-import-util@2.0.1:
-    resolution: {integrity: sha512-N1ZfNprtf/37x0R05J0QCW/9pCAcuI+bjZIK9tlu0JEkwEST7ssdD++gxHRbD58AiG5QE5OuNYhRoEFsc1wESw==}
-    engines: {node: '>= 12.*'}
-
   /babel-import-util@2.1.1:
     resolution: {integrity: sha512-3qBQWRjzP9NreSH/YrOEU1Lj5F60+pWSLP0kIdCWxjFHH7pX2YPHIxQ67el4gnMNfYoDxSDGcT0zpVlZ+gVtQA==}
     engines: {node: '>= 12.*'}
+
+  /babel-loader@8.3.0(@babel/core@7.22.5):
+    resolution: {integrity: sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==}
+    engines: {node: '>= 8.9'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      webpack: '>=2'
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+    dependencies:
+      '@babel/core': 7.22.5
+      find-cache-dir: 3.3.2
+      loader-utils: 2.0.4
+      make-dir: 3.1.0
+      schema-utils: 2.7.1
 
   /babel-loader@8.3.0(@babel/core@7.22.5)(webpack@5.80.0):
     resolution: {integrity: sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==}
@@ -6419,7 +6526,7 @@ packages:
       webpack:
         optional: true
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
@@ -6470,7 +6577,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-beta.42
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       semver: 5.7.2
 
   /babel-plugin-debug-macros@0.3.4(@babel/core@7.21.4):
@@ -6488,7 +6595,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       semver: 5.7.2
 
   /babel-plugin-ember-data-packages-polyfill@0.1.2:
@@ -6514,7 +6621,7 @@ packages:
     engines: {node: '>= 12.*'}
     dependencies:
       '@glimmer/syntax': 0.84.3
-      babel-import-util: 2.0.1
+      babel-import-util: 2.1.1
 
   /babel-plugin-filter-imports@4.0.0:
     resolution: {integrity: sha512-jDLlxI8QnfKd7PtieH6pl4tZJzymzfCDCPGdTq/grgbiYAikwDPp/oL0IlFJn0HQjLpcLkyYhPKkUVneRESw5w==}
@@ -6570,7 +6677,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.22.5
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.22.5)
       semver: 6.3.1
     transitivePeerDependencies:
@@ -6582,7 +6689,7 @@ packages:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
       '@babel/compat-data': 7.23.5
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.22.5)
       semver: 6.3.1
     transitivePeerDependencies:
@@ -6593,7 +6700,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.22.5)
       core-js-compat: 3.30.1
     transitivePeerDependencies:
@@ -6604,7 +6711,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.22.5)
       core-js-compat: 3.36.0
     transitivePeerDependencies:
@@ -6615,7 +6722,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.22.5)
     transitivePeerDependencies:
       - supports-color
@@ -6625,7 +6732,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.22.5)
     transitivePeerDependencies:
       - supports-color
@@ -7045,7 +7152,7 @@ packages:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
       http-errors: 2.0.0
@@ -7170,7 +7277,7 @@ packages:
     resolution: {integrity: sha512-6IXBgfRt7HZ61g67ssBc6lBb3Smw3DPZ9dEYirgtvXWpRZ2A9M22nxy6opEwJDgDJzlu/bB7ToppW33OFkA1gA==}
     engines: {node: '>= 6'}
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/polyfill': 7.12.1
       broccoli-funnel: 2.0.2
       broccoli-merge-trees: 3.0.2
@@ -7191,7 +7298,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.17.9
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       broccoli-persistent-filter: 3.1.3
       clone: 2.1.2
       hash-for-dep: 1.5.1
@@ -7231,7 +7338,7 @@ packages:
     dependencies:
       broccoli-kitchen-sink-helpers: 0.2.9
       broccoli-plugin: 1.1.0
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       rimraf: 2.7.1
       rsvp: 3.6.2
       walk-sync: 0.2.7
@@ -7244,7 +7351,7 @@ packages:
     dependencies:
       broccoli-kitchen-sink-helpers: 0.3.1
       broccoli-plugin: 1.3.1
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       rimraf: 2.7.1
       rsvp: 3.6.2
       walk-sync: 0.3.4
@@ -7294,7 +7401,7 @@ packages:
     dependencies:
       broccoli-kitchen-sink-helpers: 0.3.1
       broccoli-plugin: 1.3.1
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       fs-extra: 0.24.0
     transitivePeerDependencies:
       - supports-color
@@ -7325,7 +7432,7 @@ packages:
       broccoli-kitchen-sink-helpers: 0.3.1
       broccoli-plugin: 1.3.1
       copy-dereference: 1.0.0
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       mkdirp: 0.5.6
       promise-map-series: 0.2.3
       rsvp: 3.6.2
@@ -7346,7 +7453,7 @@ packages:
       array-equal: 1.0.2
       blank-object: 1.0.2
       broccoli-plugin: 1.3.1
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       fast-ordered-set: 1.0.3
       fs-tree-diff: 0.5.9
       heimdalljs: 0.2.6
@@ -7365,7 +7472,7 @@ packages:
     dependencies:
       array-equal: 1.0.2
       broccoli-plugin: 4.0.7
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       fs-tree-diff: 2.0.1
       heimdalljs: 0.2.6
       minimatch: 3.1.2
@@ -7609,7 +7716,7 @@ packages:
       broccoli-persistent-filter: 2.3.1
       broccoli-plugin: 2.1.0
       chalk: 2.4.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       ensure-posix-path: 1.1.1
       fs-extra: 8.1.0
       minimatch: 3.1.2
@@ -7639,7 +7746,7 @@ packages:
     dependencies:
       async-promise-queue: 1.0.5
       broccoli-plugin: 4.0.7
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       lodash.defaultsdeep: 4.6.1
       matcher-collection: 2.0.1
       source-map-url: 0.4.1
@@ -8201,7 +8308,7 @@ packages:
       accepts: 1.3.8
       bytes: 3.0.0
       compressible: 2.0.18
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       on-headers: 1.0.2
       safe-buffer: 5.1.2
       vary: 1.1.2
@@ -8244,7 +8351,7 @@ packages:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
     engines: {node: '>= 0.10.0'}
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       finalhandler: 1.1.2
       parseurl: 1.3.3
       utils-merge: 1.0.1
@@ -8603,6 +8710,26 @@ packages:
       postcss: 8.4.38
     dev: true
 
+  /css-loader@5.2.7:
+    resolution: {integrity: sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      webpack: ^4.27.0 || ^5.0.0
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.4.38)
+      loader-utils: 2.0.4
+      postcss: 8.4.38
+      postcss-modules-extract-imports: 3.0.0(postcss@8.4.38)
+      postcss-modules-local-by-default: 4.0.0(postcss@8.4.38)
+      postcss-modules-scope: 3.0.0(postcss@8.4.38)
+      postcss-modules-values: 4.0.0(postcss@8.4.38)
+      postcss-value-parser: 4.2.0
+      schema-utils: 3.1.2
+      semver: 7.5.0
+
   /css-loader@5.2.7(webpack@5.80.0):
     resolution: {integrity: sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==}
     engines: {node: '>= 10.13.0'}
@@ -8826,6 +8953,16 @@ packages:
       time-zone: 1.0.0
     dev: true
 
+  /debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.0.0
+
   /debug@2.6.9(supports-color@8.1.1):
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -8836,6 +8973,7 @@ packages:
     dependencies:
       ms: 2.0.0
       supports-color: 8.1.1
+    dev: true
 
   /debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -8847,6 +8985,17 @@ packages:
     dependencies:
       ms: 2.1.3
     dev: true
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
 
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -8898,6 +9047,24 @@ packages:
     dependencies:
       mimic-response: 1.0.1
     dev: true
+
+  /decorator-transforms@1.2.1(@babel/core@7.21.4):
+    resolution: {integrity: sha512-UUtmyfdlHvYoX3VSG1w5rbvBQ2r5TX1JsE4hmKU9snleFymadA3VACjl6SRfi9YgBCSjBbfQvR1bs9PRW9yBKw==}
+    dependencies:
+      '@babel/plugin-syntax-decorators': 7.23.3(@babel/core@7.21.4)
+      babel-import-util: 2.1.1
+    transitivePeerDependencies:
+      - '@babel/core'
+    dev: false
+
+  /decorator-transforms@1.2.1(@babel/core@7.22.5):
+    resolution: {integrity: sha512-UUtmyfdlHvYoX3VSG1w5rbvBQ2r5TX1JsE4hmKU9snleFymadA3VACjl6SRfi9YgBCSjBbfQvR1bs9PRW9yBKw==}
+    dependencies:
+      '@babel/plugin-syntax-decorators': 7.23.3(@babel/core@7.22.5)
+      babel-import-util: 2.1.1
+    transitivePeerDependencies:
+      - '@babel/core'
+    dev: false
 
   /deep-equal@2.2.0:
     resolution: {integrity: sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==}
@@ -9175,16 +9342,91 @@ packages:
   /electron-to-chromium@1.4.715:
     resolution: {integrity: sha512-XzWNH4ZSa9BwVUQSDorPWAUQ5WGuYz7zJUNpNif40zFCiCl20t8zgylmreNmn26h5kiyw2lg7RfTmeMBsDklqg==}
 
-  /ember-auto-import@2.6.3(webpack@5.80.0):
+  /ember-async-data@1.0.3(ember-source@3.28.11):
+    resolution: {integrity: sha512-54OtoQwNi+/ZvPOVuT4t8fcHR9xL8N7kBydzcZSo6BIEsLYeXPi3+jUR8niWjfjXXhKlJ8EWXR0lTeHleTrxbw==}
+    peerDependencies:
+      ember-source: '>=4.8.4'
+    dependencies:
+      '@ember/test-waiters': 3.0.2
+      '@embroider/addon-shim': 1.8.9
+      ember-source: 3.28.11(@babel/core@7.21.4)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /ember-async-data@1.0.3(ember-source@4.10.0):
+    resolution: {integrity: sha512-54OtoQwNi+/ZvPOVuT4t8fcHR9xL8N7kBydzcZSo6BIEsLYeXPi3+jUR8niWjfjXXhKlJ8EWXR0lTeHleTrxbw==}
+    peerDependencies:
+      ember-source: '>=4.8.4'
+    dependencies:
+      '@ember/test-waiters': 3.0.2
+      '@embroider/addon-shim': 1.8.9
+      ember-source: 4.10.0(@babel/core@7.21.4)(@glimmer/component@1.1.2)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /ember-async-data@1.0.3(ember-source@4.12.0):
+    resolution: {integrity: sha512-54OtoQwNi+/ZvPOVuT4t8fcHR9xL8N7kBydzcZSo6BIEsLYeXPi3+jUR8niWjfjXXhKlJ8EWXR0lTeHleTrxbw==}
+    peerDependencies:
+      ember-source: '>=4.8.4'
+    dependencies:
+      '@ember/test-waiters': 3.0.2
+      '@embroider/addon-shim': 1.8.9
+      ember-source: 4.12.0(@babel/core@7.22.5)(@glimmer/component@1.1.2)(webpack@5.83.1)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /ember-auto-import@2.6.3:
     resolution: {integrity: sha512-uLhrRDJYWCRvQ4JQ1e64XlSrqAKSd6PXaJ9ZsZI6Tlms9T4DtQFxNXasqji2ZRJBVrxEoLCRYX3RTldsQ0vNGQ==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.22.5)
       '@babel/plugin-proposal-decorators': 7.21.0(@babel/core@7.22.5)
       '@babel/preset-env': 7.21.4(@babel/core@7.22.5)
       '@embroider/macros': 1.10.0
-      '@embroider/shared-internals': 2.6.1
+      '@embroider/shared-internals': 2.0.0
+      babel-loader: 8.3.0(@babel/core@7.22.5)
+      babel-plugin-ember-modules-api-polyfill: 3.5.0
+      babel-plugin-ember-template-compilation: 2.0.2
+      babel-plugin-htmlbars-inline-precompile: 5.3.1
+      babel-plugin-syntax-dynamic-import: 6.18.0
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      broccoli-plugin: 4.0.7
+      broccoli-source: 3.0.1
+      css-loader: 5.2.7
+      debug: 4.3.4
+      fs-extra: 10.1.0
+      fs-tree-diff: 2.0.1
+      handlebars: 4.7.7
+      js-string-escape: 1.0.1
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.7.5
+      parse5: 6.0.1
+      resolve: 1.22.2
+      resolve-package-path: 4.0.3
+      semver: 7.5.0
+      style-loader: 2.0.0
+      typescript-memoize: 1.1.1
+      walk-sync: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+      - webpack
+
+  /ember-auto-import@2.6.3(webpack@5.80.0):
+    resolution: {integrity: sha512-uLhrRDJYWCRvQ4JQ1e64XlSrqAKSd6PXaJ9ZsZI6Tlms9T4DtQFxNXasqji2ZRJBVrxEoLCRYX3RTldsQ0vNGQ==}
+    engines: {node: 12.* || 14.* || >= 16}
+    dependencies:
+      '@babel/core': 7.22.5
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.22.5)
+      '@babel/plugin-proposal-decorators': 7.21.0(@babel/core@7.22.5)
+      '@babel/preset-env': 7.21.4(@babel/core@7.22.5)
+      '@embroider/macros': 1.10.0
+      '@embroider/shared-internals': 2.0.0
       babel-loader: 8.3.0(@babel/core@7.22.5)(webpack@5.80.0)
       babel-plugin-ember-modules-api-polyfill: 3.5.0
       babel-plugin-ember-template-compilation: 2.0.2
@@ -9196,7 +9438,7 @@ packages:
       broccoli-plugin: 4.0.7
       broccoli-source: 3.0.1
       css-loader: 5.2.7(webpack@5.80.0)
-      debug: 4.3.5
+      debug: 4.3.4
       fs-extra: 10.1.0
       fs-tree-diff: 2.0.1
       handlebars: 4.7.7
@@ -9218,7 +9460,7 @@ packages:
     resolution: {integrity: sha512-uLhrRDJYWCRvQ4JQ1e64XlSrqAKSd6PXaJ9ZsZI6Tlms9T4DtQFxNXasqji2ZRJBVrxEoLCRYX3RTldsQ0vNGQ==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.22.5)
       '@babel/plugin-proposal-decorators': 7.21.0(@babel/core@7.22.5)
       '@babel/preset-env': 7.21.4(@babel/core@7.22.5)
@@ -9235,7 +9477,7 @@ packages:
       broccoli-plugin: 4.0.7
       broccoli-source: 3.0.1
       css-loader: 5.2.7(webpack@5.83.1)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       fs-extra: 10.1.0
       fs-tree-diff: 2.0.1
       handlebars: 4.7.7
@@ -9340,6 +9582,60 @@ packages:
       - supports-color
     dev: false
 
+  /ember-cached-decorator-polyfill@1.0.2(@babel/core@7.21.4)(ember-source@3.28.11):
+    resolution: {integrity: sha512-hUX6OYTKltAPAu8vsVZK02BfMTV0OUXrPqvRahYPhgS7D0I6joLjlskd7mhqJMcaXLywqceIy8/s+x8bxF8bpQ==}
+    engines: {node: 14.* || >= 16}
+    peerDependencies:
+      ember-source: ^3.13.0 || ^4.0.0 || >= 5.0.0
+    dependencies:
+      '@embroider/macros': 1.10.0
+      '@glimmer/tracking': 1.1.2
+      babel-import-util: 1.3.0
+      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.21.4)
+      ember-cli-babel: 7.26.11
+      ember-cli-babel-plugin-helpers: 1.1.1
+      ember-source: 3.28.11(@babel/core@7.21.4)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+    dev: false
+
+  /ember-cached-decorator-polyfill@1.0.2(@babel/core@7.21.4)(ember-source@4.10.0):
+    resolution: {integrity: sha512-hUX6OYTKltAPAu8vsVZK02BfMTV0OUXrPqvRahYPhgS7D0I6joLjlskd7mhqJMcaXLywqceIy8/s+x8bxF8bpQ==}
+    engines: {node: 14.* || >= 16}
+    peerDependencies:
+      ember-source: ^3.13.0 || ^4.0.0 || >= 5.0.0
+    dependencies:
+      '@embroider/macros': 1.10.0
+      '@glimmer/tracking': 1.1.2
+      babel-import-util: 1.3.0
+      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.21.4)
+      ember-cli-babel: 7.26.11
+      ember-cli-babel-plugin-helpers: 1.1.1
+      ember-source: 4.10.0(@babel/core@7.21.4)(@glimmer/component@1.1.2)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+    dev: false
+
+  /ember-cached-decorator-polyfill@1.0.2(@babel/core@7.22.5)(ember-source@4.12.0):
+    resolution: {integrity: sha512-hUX6OYTKltAPAu8vsVZK02BfMTV0OUXrPqvRahYPhgS7D0I6joLjlskd7mhqJMcaXLywqceIy8/s+x8bxF8bpQ==}
+    engines: {node: 14.* || >= 16}
+    peerDependencies:
+      ember-source: ^3.13.0 || ^4.0.0 || >= 5.0.0
+    dependencies:
+      '@embroider/macros': 1.10.0
+      '@glimmer/tracking': 1.1.2
+      babel-import-util: 1.3.0
+      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.22.5)
+      ember-cli-babel: 7.26.11
+      ember-cli-babel-plugin-helpers: 1.1.1
+      ember-source: 4.12.0(@babel/core@7.22.5)(@glimmer/component@1.1.2)(webpack@5.83.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+    dev: false
+
   /ember-cli-app-version@6.0.1(ember-source@3.28.11):
     resolution: {integrity: sha512-XA1FwkWA5QytmWF0jcJqEr3jcZoiCl9Fb33TZgOVfClL7Voxe+/RwzISEprBRQgbf7j8z1xf8/RJCKfclUy3rQ==}
     engines: {node: 14.* || 16.* || >= 18}
@@ -9374,7 +9670,7 @@ packages:
     resolution: {integrity: sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==}
     engines: {node: 6.* || 8.* || >= 10.*}
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.22.5)
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.22.5)
       '@babel/plugin-proposal-decorators': 7.21.0(@babel/core@7.22.5)
@@ -9413,7 +9709,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.22.5)
       '@babel/plugin-proposal-decorators': 7.23.9(@babel/core@7.22.5)
@@ -9638,7 +9934,7 @@ packages:
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.21.4)
       '@babel/plugin-transform-typescript': 7.4.5(@babel/core@7.21.4)
       ansi-to-html: 0.6.15
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       ember-cli-babel-plugin-helpers: 1.1.1
       execa: 1.0.0
       fs-extra: 7.0.1
@@ -9659,7 +9955,7 @@ packages:
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.22.5)
       '@babel/plugin-transform-typescript': 7.4.5(@babel/core@7.22.5)
       ansi-to-html: 0.6.15
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       ember-cli-babel-plugin-helpers: 1.1.1
       execa: 1.0.0
       fs-extra: 7.0.1
@@ -9679,7 +9975,7 @@ packages:
     dependencies:
       '@babel/plugin-transform-typescript': 7.5.5(@babel/core@7.21.4)
       ansi-to-html: 0.6.15
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       ember-cli-babel-plugin-helpers: 1.1.1
       execa: 2.1.0
       fs-extra: 8.1.0
@@ -9698,7 +9994,7 @@ packages:
     dependencies:
       '@babel/plugin-transform-typescript': 7.5.5(@babel/core@7.22.5)
       ansi-to-html: 0.6.15
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       ember-cli-babel-plugin-helpers: 1.1.1
       execa: 2.1.0
       fs-extra: 8.1.0
@@ -9740,7 +10036,7 @@ packages:
     dependencies:
       ansi-to-html: 0.6.15
       broccoli-stew: 3.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       execa: 4.1.0
       fs-extra: 9.1.0
       resolve: 1.22.8
@@ -9757,7 +10053,7 @@ packages:
     dependencies:
       ansi-to-html: 0.6.15
       broccoli-stew: 3.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       execa: 4.1.0
       fs-extra: 9.1.0
       resolve: 1.22.2
@@ -9819,7 +10115,7 @@ packages:
     engines: {node: '>= 14'}
     hasBin: true
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/plugin-transform-modules-amd': 7.20.11(@babel/core@7.22.5)
       amd-name-resolver: 1.3.1
       babel-plugin-module-resolver: 4.1.0
@@ -9976,7 +10272,7 @@ packages:
     engines: {node: '>= 14'}
     hasBin: true
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/plugin-transform-modules-amd': 7.20.11(@babel/core@7.22.5)
       amd-name-resolver: 1.3.1
       babel-plugin-module-resolver: 4.1.0
@@ -10292,6 +10588,72 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /ember-modify-based-class-resource@1.1.0(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(ember-resources@7.0.2)(ember-source@3.28.11):
+    resolution: {integrity: sha512-35PqPA6XFncpJkePr1Zs5aR/bANpsCEa8X7fXkA0EkTyuILqP3ycqtlfK0VxkADz62lk86BR8biGsTz0jgdZUQ==}
+    peerDependencies:
+      '@glimmer/component': ^1.1.2
+      '@glimmer/tracking': ^1.1.2
+      ember-resources: '>= 6.4.0'
+      ember-source: ^3.28.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      '@glimmer/component':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@embroider/addon-shim': 1.8.9
+      '@embroider/macros': 1.10.0
+      '@glimmer/component': 1.1.2(@babel/core@7.21.4)
+      '@glimmer/tracking': 1.1.2
+      ember-resources: 7.0.2(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@3.28.11)
+      ember-source: 3.28.11(@babel/core@7.21.4)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /ember-modify-based-class-resource@1.1.0(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(ember-resources@7.0.2)(ember-source@4.10.0):
+    resolution: {integrity: sha512-35PqPA6XFncpJkePr1Zs5aR/bANpsCEa8X7fXkA0EkTyuILqP3ycqtlfK0VxkADz62lk86BR8biGsTz0jgdZUQ==}
+    peerDependencies:
+      '@glimmer/component': ^1.1.2
+      '@glimmer/tracking': ^1.1.2
+      ember-resources: '>= 6.4.0'
+      ember-source: ^3.28.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      '@glimmer/component':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@embroider/addon-shim': 1.8.9
+      '@embroider/macros': 1.10.0
+      '@glimmer/component': 1.1.2(@babel/core@7.21.4)
+      '@glimmer/tracking': 1.1.2
+      ember-resources: 7.0.2(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.10.0)
+      ember-source: 4.10.0(@babel/core@7.21.4)(@glimmer/component@1.1.2)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /ember-modify-based-class-resource@1.1.0(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(ember-resources@7.0.2)(ember-source@4.12.0):
+    resolution: {integrity: sha512-35PqPA6XFncpJkePr1Zs5aR/bANpsCEa8X7fXkA0EkTyuILqP3ycqtlfK0VxkADz62lk86BR8biGsTz0jgdZUQ==}
+    peerDependencies:
+      '@glimmer/component': ^1.1.2
+      '@glimmer/tracking': ^1.1.2
+      ember-resources: '>= 6.4.0'
+      ember-source: ^3.28.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      '@glimmer/component':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@embroider/addon-shim': 1.8.9
+      '@embroider/macros': 1.10.0
+      '@glimmer/component': 1.1.2(@babel/core@7.22.5)
+      '@glimmer/tracking': 1.1.2
+      ember-resources: 7.0.2(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.12.0)
+      ember-source: 4.12.0(@babel/core@7.22.5)(@glimmer/component@1.1.2)(webpack@5.83.1)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /ember-page-title@8.0.0-beta.0:
     resolution: {integrity: sha512-n4GGCEq2w4LLbuWfhNCW4qpFYjpgHQcoxyQVUXeFrm8zy/+vx1hKvsKp6dQ0zSZGDn2Cr/znp1GLuieWUuU1dg==}
     engines: {node: 12.* || 14.* || >= 16}
@@ -10360,7 +10722,7 @@ packages:
       - supports-color
     dev: true
 
-  /ember-resolver@10.0.0(@ember/string@3.1.1)(ember-source@4.12.0):
+  /ember-resolver@10.0.0(ember-source@4.12.0):
     resolution: {integrity: sha512-e99wFJ4ZpleJ6JMEcIk4WEYP4s3nc+9/iNSXtwBHXC8ADJHJTeN3HjnT/eEbFbswdui4FYxIYuK+UCdP09811Q==}
     engines: {node: 14.* || 16.* || >= 18}
     peerDependencies:
@@ -10370,7 +10732,6 @@ packages:
       ember-source:
         optional: true
     dependencies:
-      '@ember/string': 3.1.1
       ember-cli-babel: 7.26.11
       ember-source: 4.12.0(@babel/core@7.22.5)(@glimmer/component@1.1.2)(webpack@5.83.1)
     transitivePeerDependencies:
@@ -10421,64 +10782,6 @@ packages:
       - supports-color
     dev: false
 
-  /ember-resources@5.6.4(@ember/test-waiters@3.0.2)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.10.0):
-    resolution: {integrity: sha512-ShdosnruPm37jPpzPOgPVelymEDJT/27Jz/j5AGPVAfCaUhRIocTxNMtPx13ox890A2babuPF5M3Ur8UFidqtw==}
-    peerDependencies:
-      '@ember/test-waiters': ^3.0.0
-      '@glimmer/component': ^1.1.2
-      '@glimmer/tracking': ^1.1.2
-      '@glint/template': '>= 0.8.3'
-      ember-concurrency: ^2.0.0
-      ember-source: '>= 3.28.0'
-    peerDependenciesMeta:
-      '@ember/test-waiters':
-        optional: true
-      '@glimmer/component':
-        optional: true
-      ember-concurrency:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@ember/test-waiters': 3.0.2
-      '@embroider/addon-shim': 1.8.4
-      '@embroider/macros': 1.10.0
-      '@glimmer/component': 1.1.2(@babel/core@7.21.4)
-      '@glimmer/tracking': 1.1.2
-      '@glint/template': 1.0.2
-      ember-source: 4.10.0(@babel/core@7.21.4)(@glimmer/component@1.1.2)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /ember-resources@5.6.4(@ember/test-waiters@3.0.2)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.12.0):
-    resolution: {integrity: sha512-ShdosnruPm37jPpzPOgPVelymEDJT/27Jz/j5AGPVAfCaUhRIocTxNMtPx13ox890A2babuPF5M3Ur8UFidqtw==}
-    peerDependencies:
-      '@ember/test-waiters': ^3.0.0
-      '@glimmer/component': ^1.1.2
-      '@glimmer/tracking': ^1.1.2
-      '@glint/template': '>= 0.8.3'
-      ember-concurrency: ^2.0.0
-      ember-source: '>= 3.28.0'
-    peerDependenciesMeta:
-      '@ember/test-waiters':
-        optional: true
-      '@glimmer/component':
-        optional: true
-      ember-concurrency:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.21.5
-      '@ember/test-waiters': 3.0.2
-      '@embroider/addon-shim': 1.8.4
-      '@embroider/macros': 1.10.0
-      '@glimmer/component': 1.1.2(@babel/core@7.22.5)
-      '@glimmer/tracking': 1.1.2
-      '@glint/template': 1.0.2
-      ember-source: 4.12.0(@babel/core@7.22.5)(@glimmer/component@1.1.2)(webpack@5.83.1)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /ember-resources@6.0.0(@ember/test-waiters@3.0.2)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.12.0):
     resolution: {integrity: sha512-2jq1ZIZdzJfypstu+7qpXCd02hSkfpj2N2kfnRSNSomq7bihyLIPnzTkP07puLln+j3fssiAA5vkuZxuboLEpQ==}
     peerDependencies:
@@ -10511,6 +10814,69 @@ packages:
       - supports-color
     dev: false
 
+  /ember-resources@7.0.2(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@3.28.11):
+    resolution: {integrity: sha512-WbTdfgMn2bIuuWIXl8PlS4wj3zBO1+plRI63XF9pUhk1ltE31P53ns28+e0EYdYyN9KtZ9di7ZsRLEWO2dHJGw==}
+    peerDependencies:
+      '@glimmer/component': '>= 1.1.2'
+      '@glimmer/tracking': '>= 1.1.2'
+      '@glint/template': '>= 1.0.0'
+      ember-source: ^3.28.0 || ^4.0.0 || >= 5.0.0
+    peerDependenciesMeta:
+      '@glimmer/component':
+        optional: true
+    dependencies:
+      '@embroider/addon-shim': 1.8.9
+      '@embroider/macros': 1.10.0
+      '@glimmer/component': 1.1.2(@babel/core@7.21.4)
+      '@glimmer/tracking': 1.1.2
+      '@glint/template': 1.0.2
+      ember-source: 3.28.11(@babel/core@7.21.4)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /ember-resources@7.0.2(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.10.0):
+    resolution: {integrity: sha512-WbTdfgMn2bIuuWIXl8PlS4wj3zBO1+plRI63XF9pUhk1ltE31P53ns28+e0EYdYyN9KtZ9di7ZsRLEWO2dHJGw==}
+    peerDependencies:
+      '@glimmer/component': '>= 1.1.2'
+      '@glimmer/tracking': '>= 1.1.2'
+      '@glint/template': '>= 1.0.0'
+      ember-source: ^3.28.0 || ^4.0.0 || >= 5.0.0
+    peerDependenciesMeta:
+      '@glimmer/component':
+        optional: true
+    dependencies:
+      '@embroider/addon-shim': 1.8.9
+      '@embroider/macros': 1.10.0
+      '@glimmer/component': 1.1.2(@babel/core@7.21.4)
+      '@glimmer/tracking': 1.1.2
+      '@glint/template': 1.0.2
+      ember-source: 4.10.0(@babel/core@7.21.4)(@glimmer/component@1.1.2)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /ember-resources@7.0.2(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.12.0):
+    resolution: {integrity: sha512-WbTdfgMn2bIuuWIXl8PlS4wj3zBO1+plRI63XF9pUhk1ltE31P53ns28+e0EYdYyN9KtZ9di7ZsRLEWO2dHJGw==}
+    peerDependencies:
+      '@glimmer/component': '>= 1.1.2'
+      '@glimmer/tracking': '>= 1.1.2'
+      '@glint/template': '>= 1.0.0'
+      ember-source: ^3.28.0 || ^4.0.0 || >= 5.0.0
+    peerDependenciesMeta:
+      '@glimmer/component':
+        optional: true
+    dependencies:
+      '@embroider/addon-shim': 1.8.9
+      '@embroider/macros': 1.10.0
+      '@glimmer/component': 1.1.2(@babel/core@7.22.5)
+      '@glimmer/tracking': 1.1.2
+      '@glint/template': 1.0.2
+      ember-source: 4.12.0(@babel/core@7.22.5)(@glimmer/component@1.1.2)(webpack@5.83.1)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /ember-rfc176-data@0.3.18:
     resolution: {integrity: sha512-JtuLoYGSjay1W3MQAxt3eINWXNYYQliK90tLwtb8aeCuQK8zKGCRbBodVIrkcTqshULMnRuTOS6t1P7oQk3g6Q==}
 
@@ -10519,7 +10885,7 @@ packages:
     engines: {node: 8.* || 10.* || >= 12}
     dependencies:
       '@babel/parser': 7.22.5
-      '@babel/traverse': 7.22.5(supports-color@8.1.1)
+      '@babel/traverse': 7.22.5
       recast: 0.18.10
     transitivePeerDependencies:
       - supports-color
@@ -10587,7 +10953,7 @@ packages:
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
-      ember-auto-import: 2.6.3(webpack@5.80.0)
+      ember-auto-import: 2.6.3
       ember-cli-babel: 7.26.11
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0
@@ -10750,7 +11116,7 @@ packages:
       chalk: 4.1.2
       cli-table3: 0.6.3
       core-object: 3.1.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       ember-try-config: 4.0.0
       execa: 4.1.0
       fs-extra: 9.1.0
@@ -11044,10 +11410,10 @@ packages:
       eslint: '*'
       eslint-plugin-import: '*'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       enhanced-resolve: 5.14.0
       eslint: 7.32.0
-      eslint-module-utils: 2.8.0(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@7.32.0)
+      eslint-module-utils: 2.8.0(eslint-import-resolver-typescript@3.5.5)(eslint@7.32.0)
       eslint-plugin-import: 2.27.5(eslint-import-resolver-typescript@3.5.5)(eslint@7.32.0)
       get-tsconfig: 4.5.0
       globby: 13.1.4
@@ -11119,6 +11485,34 @@ packages:
       - supports-color
     dev: true
 
+  /eslint-module-utils@2.8.0(eslint-import-resolver-typescript@3.5.5)(eslint@7.32.0):
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      debug: 3.2.7
+      eslint: 7.32.0
+      eslint-import-resolver-typescript: 3.5.5(eslint-plugin-import@2.27.5)(eslint@7.32.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /eslint-plugin-decorator-position@5.0.1(@babel/eslint-parser@7.21.3)(eslint@7.32.0):
     resolution: {integrity: sha512-2VI4qzKhdIvWR/+VIsIcUQLVS49E5/LNOKHccV+di23IqeY0JRTefjSAuHpsEjF/KTEciH2LVsxFltgV1/kw2w==}
     engines: {node: '>=14'}
@@ -11129,7 +11523,7 @@ packages:
       '@babel/eslint-parser':
         optional: true
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/eslint-parser': 7.21.3(@babel/core@7.21.4)(eslint@7.32.0)
       '@babel/plugin-proposal-decorators': 7.21.0(@babel/core@7.22.5)
       '@ember-data/rfc395-data': 0.0.4
@@ -11150,7 +11544,7 @@ packages:
       '@babel/eslint-parser':
         optional: true
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/eslint-parser': 7.21.3(@babel/core@7.22.5)(eslint@7.32.0)
       '@babel/plugin-proposal-decorators': 7.21.0(@babel/core@7.22.5)
       '@ember-data/rfc395-data': 0.0.4
@@ -11252,7 +11646,7 @@ packages:
       is-glob: 4.0.3
       minimatch: 3.1.2
       object.values: 1.1.6
-      resolve: 1.22.8
+      resolve: 1.22.2
       semver: 6.3.1
       tsconfig-paths: 3.14.2
     transitivePeerDependencies:
@@ -11278,7 +11672,7 @@ packages:
       doctrine: 2.1.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.41.0)(eslint-import-resolver-node@0.3.7)(eslint@7.32.0)
+      eslint-module-utils: 2.8.0(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@7.32.0)
       has: 1.0.3
       is-core-module: 2.12.0
       is-glob: 4.0.3
@@ -11453,7 +11847,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       doctrine: 3.0.0
       enquirer: 2.3.6
       escape-string-regexp: 4.0.0
@@ -11666,7 +12060,7 @@ packages:
     resolution: {integrity: sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==}
     engines: {node: '>=0.10.0'}
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       define-property: 0.2.5
       extend-shallow: 2.0.1
       posix-character-classes: 0.1.1
@@ -11703,7 +12097,7 @@ packages:
       content-type: 1.0.5
       cookie: 0.5.0
       cookie-signature: 1.0.6
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       encodeurl: 1.0.2
       escape-html: 1.0.3
@@ -11914,7 +12308,7 @@ packages:
     resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
     engines: {node: '>= 0.8'}
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       encodeurl: 1.0.2
       escape-html: 1.0.3
       on-finished: 2.3.0
@@ -11929,7 +12323,7 @@ packages:
     resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
     engines: {node: '>= 0.8'}
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       encodeurl: 1.0.2
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -12749,7 +13143,7 @@ packages:
   /heimdalljs-logger@0.1.10:
     resolution: {integrity: sha512-pO++cJbhIufVI/fmB/u2Yty3KJD0TqNPecehFae0/eps0hkZ3b4Zc/PezUMOpYuHFQbA7FxHZxa305EhmjLj4g==}
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       heimdalljs: 0.2.6
     transitivePeerDependencies:
       - supports-color
@@ -12853,6 +13247,16 @@ packages:
     resolution: {integrity: sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==}
     dev: true
 
+  /http-proxy-agent@4.0.1:
+    resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
+    engines: {node: '>= 6'}
+    dependencies:
+      '@tootallnate/once': 1.1.2
+      agent-base: 6.0.2
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+
   /http-proxy-agent@4.0.1(supports-color@8.1.1):
     resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
     engines: {node: '>= 6'}
@@ -12862,6 +13266,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /http-proxy@1.18.1:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
@@ -12874,6 +13279,15 @@ packages:
       - debug
     dev: true
 
+  /https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+
   /https-proxy-agent@5.0.1(supports-color@8.1.1):
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
@@ -12882,6 +13296,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /https@1.0.0:
     resolution: {integrity: sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==}
@@ -13521,6 +13936,47 @@ packages:
       argparse: 2.0.1
     dev: true
 
+  /jsdom@16.7.0:
+    resolution: {integrity: sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+    dependencies:
+      abab: 2.0.6
+      acorn: 8.8.2
+      acorn-globals: 6.0.0
+      cssom: 0.4.4
+      cssstyle: 2.3.0
+      data-urls: 2.0.0
+      decimal.js: 10.4.3
+      domexception: 2.0.1
+      escodegen: 2.0.0
+      form-data: 3.0.1
+      html-encoding-sniffer: 2.0.1
+      http-proxy-agent: 4.0.1
+      https-proxy-agent: 5.0.1
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.4
+      parse5: 6.0.1
+      saxes: 5.0.1
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.2
+      w3c-hr-time: 1.0.2
+      w3c-xmlserializer: 2.0.0
+      webidl-conversions: 6.1.0
+      whatwg-encoding: 1.0.5
+      whatwg-mimetype: 2.3.0
+      whatwg-url: 8.7.0
+      ws: 7.5.9
+      xml-name-validator: 3.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   /jsdom@16.7.0(supports-color@8.1.1):
     resolution: {integrity: sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==}
     engines: {node: '>=10'}
@@ -13561,6 +14017,7 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
+    dev: true
 
   /jsesc@0.3.0:
     resolution: {integrity: sha512-UHQmAeTXV+iwEk0aHheJRqo6Or90eDxI6KIYpHSjKLXKuKlPt1CQ7tGBerFcFA8uKU5mYxiPMlckmFptd5XZzA==}
@@ -13700,7 +14157,7 @@ packages:
   /leek@0.0.24:
     resolution: {integrity: sha512-6PVFIYXxlYF0o6hrAsHtGpTmi06otkwNrMcmQ0K96SeSRHPREPa9J3nJZ1frliVH7XT0XFswoJFQoXsDukzGNQ==}
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       lodash.assign: 3.2.0
       rsvp: 3.6.2
     transitivePeerDependencies:
@@ -14384,7 +14841,7 @@ packages:
   /micromark@2.11.4:
     resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -14456,6 +14913,17 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
     dev: true
+
+  /mini-css-extract-plugin@2.7.5:
+    resolution: {integrity: sha512-9HaR++0mlgom81s95vvNjxkg52n2b5s//3ZTI1EtzFb98awsLSivs2LMsVqnQ3ay0PVhqWcGNyDaTE961FOcjQ==}
+    engines: {node: '>= 12.13.0'}
+    peerDependencies:
+      webpack: ^5.0.0
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+    dependencies:
+      schema-utils: 4.0.1
 
   /mini-css-extract-plugin@2.7.5(webpack@5.80.0):
     resolution: {integrity: sha512-9HaR++0mlgom81s95vvNjxkg52n2b5s//3ZTI1EtzFb98awsLSivs2LMsVqnQ3ay0PVhqWcGNyDaTE961FOcjQ==}
@@ -14560,7 +15028,7 @@ packages:
     engines: {node: '>= 0.8.0'}
     dependencies:
       basic-auth: 2.0.1
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       on-finished: 2.3.0
       on-headers: 1.0.2
@@ -15759,7 +16227,7 @@ packages:
     resolution: {integrity: sha512-L/15ujsvuOpuIB9y9XJJs/QOPgdot76T0U1Q34C19igS1lsaL/cdRw8rXIVC5Z2x362yZI33Qodo//7kK7ItkA==}
     engines: {node: 14.* || 16.* || >= 18}
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@glimmer/syntax': 0.84.3
       ember-cli-htmlbars: 6.2.0
       ember-template-imports: 3.4.2
@@ -15972,6 +16440,72 @@ packages:
       strip-json-comments: 2.0.1
     dev: true
 
+  /reactiveweb@1.3.0(@babel/core@7.21.4)(@ember/test-waiters@3.0.2)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@3.28.11):
+    resolution: {integrity: sha512-+HIF4nW2iiHrZYvMyaFJopL/ljEW8e8s9HS+I6kAtSeJqtJtox577qviywU8ffHRmHPZP4owTlSWg3F4nAj4Vg==}
+    peerDependencies:
+      '@ember/test-waiters': '>= 3.1.0'
+      ember-source: '>= 3.28.0'
+    dependencies:
+      '@ember/test-waiters': 3.0.2
+      '@embroider/addon-shim': 1.8.9
+      '@embroider/macros': 1.10.0
+      decorator-transforms: 1.2.1(@babel/core@7.21.4)
+      ember-async-data: 1.0.3(ember-source@3.28.11)
+      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.21.4)(ember-source@3.28.11)
+      ember-resources: 7.0.2(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@3.28.11)
+      ember-source: 3.28.11(@babel/core@7.21.4)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glimmer/component'
+      - '@glimmer/tracking'
+      - '@glint/template'
+      - supports-color
+    dev: false
+
+  /reactiveweb@1.3.0(@babel/core@7.21.4)(@ember/test-waiters@3.0.2)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.10.0):
+    resolution: {integrity: sha512-+HIF4nW2iiHrZYvMyaFJopL/ljEW8e8s9HS+I6kAtSeJqtJtox577qviywU8ffHRmHPZP4owTlSWg3F4nAj4Vg==}
+    peerDependencies:
+      '@ember/test-waiters': '>= 3.1.0'
+      ember-source: '>= 3.28.0'
+    dependencies:
+      '@ember/test-waiters': 3.0.2
+      '@embroider/addon-shim': 1.8.9
+      '@embroider/macros': 1.10.0
+      decorator-transforms: 1.2.1(@babel/core@7.21.4)
+      ember-async-data: 1.0.3(ember-source@4.10.0)
+      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.21.4)(ember-source@4.10.0)
+      ember-resources: 7.0.2(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.10.0)
+      ember-source: 4.10.0(@babel/core@7.21.4)(@glimmer/component@1.1.2)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glimmer/component'
+      - '@glimmer/tracking'
+      - '@glint/template'
+      - supports-color
+    dev: false
+
+  /reactiveweb@1.3.0(@babel/core@7.22.5)(@ember/test-waiters@3.0.2)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.12.0):
+    resolution: {integrity: sha512-+HIF4nW2iiHrZYvMyaFJopL/ljEW8e8s9HS+I6kAtSeJqtJtox577qviywU8ffHRmHPZP4owTlSWg3F4nAj4Vg==}
+    peerDependencies:
+      '@ember/test-waiters': '>= 3.1.0'
+      ember-source: '>= 3.28.0'
+    dependencies:
+      '@ember/test-waiters': 3.0.2
+      '@embroider/addon-shim': 1.8.9
+      '@embroider/macros': 1.10.0
+      decorator-transforms: 1.2.1(@babel/core@7.22.5)
+      ember-async-data: 1.0.3(ember-source@4.12.0)
+      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.22.5)(ember-source@4.12.0)
+      ember-resources: 7.0.2(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.12.0)
+      ember-source: 4.12.0(@babel/core@7.22.5)(@glimmer/component@1.1.2)(webpack@5.83.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glimmer/component'
+      - '@glimmer/tracking'
+      - '@glint/template'
+      - supports-color
+    dev: false
+
   /read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
     dependencies:
@@ -16087,7 +16621,7 @@ packages:
   /regenerator-transform@0.15.2:
     resolution: {integrity: sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==}
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.24.7
 
   /regex-not@1.0.2:
     resolution: {integrity: sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==}
@@ -16225,7 +16759,7 @@ packages:
   /remove-types@1.0.0:
     resolution: {integrity: sha512-G7Hk1Q+UJ5DvlNAoJZObxANkBZGiGdp589rVcTW/tYqJWJ5rwfraSnKSQaETN8Epaytw8J40nS/zC7bcHGv36w==}
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       '@babel/plugin-syntax-decorators': 7.23.3(@babel/core@7.22.5)
       '@babel/plugin-transform-typescript': 7.23.6(@babel/core@7.22.5)
       prettier: 2.8.7
@@ -16652,7 +17186,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.12.0
-      ajv-formats: 2.1.1(ajv@8.12.0)
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0(ajv@8.12.0)
 
   /semver@5.7.1:
@@ -16702,7 +17236,7 @@ packages:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
     engines: {node: '>= 0.8.0'}
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 1.0.2
@@ -16821,7 +17355,7 @@ packages:
   /silent-error@1.1.1:
     resolution: {integrity: sha512-n4iEKyNcg4v6/jpb3c0/iyH2G1nzUNl7Gpqtn/mHIJK9S/q/7MCfoO4rwVOoO59qPFIc0hVHvMbiOJ0NdtxKKw==}
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
     transitivePeerDependencies:
       - supports-color
 
@@ -16892,7 +17426,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       base: 0.11.2
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       define-property: 0.2.5
       extend-shallow: 2.0.1
       map-cache: 0.2.2
@@ -17085,7 +17619,7 @@ packages:
     resolution: {integrity: sha512-GqXBq2SPWv9hTXDFKS8WrKK1aISB0aKGHZzH+uD4ShAgs+Fz20ZfoerLOm8U+f62iRWLrw6nimOY/uYuTcVhvg==}
     engines: {node: 6.* || 8.* || >= 10.*}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -17258,6 +17792,18 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /style-loader@2.0.0:
+    resolution: {integrity: sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+    dependencies:
+      loader-utils: 2.0.4
+      schema-utils: 3.1.2
+
   /style-loader@2.0.0(webpack@5.80.0):
     resolution: {integrity: sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==}
     engines: {node: '>= 10.13.0'}
@@ -17367,7 +17913,7 @@ packages:
   /sync-disk-cache@1.3.4:
     resolution: {integrity: sha512-GlkGeM81GPPEKz/lH7QUTbvqLq7K/IUTuaKDSMulP9XQ42glqNJIN/RKgSOw4y8vxL1gOVvj+W7ruEO4s36eCw==}
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       heimdalljs: 0.2.6
       mkdirp: 0.5.6
       rimraf: 2.7.1
@@ -17379,7 +17925,7 @@ packages:
     resolution: {integrity: sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==}
     engines: {node: 8.* || >= 10.*}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       heimdalljs: 0.2.6
       mkdirp: 0.5.6
       rimraf: 3.0.2
@@ -17861,7 +18407,7 @@ packages:
   /tree-sync@1.4.0:
     resolution: {integrity: sha512-YvYllqh3qrR5TAYZZTXdspnIhlKAYezPYw11ntmweoceu4VK+keN356phHRIIo1d+RDmLpHZrUlmxga2gc9kSQ==}
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       fs-tree-diff: 0.5.9
       mkdirp: 0.5.6
       quick-temp: 0.1.8
@@ -17873,7 +18419,7 @@ packages:
     resolution: {integrity: sha512-OLWW+Nd99NOM53aZ8ilT/YpEiOo6mXD3F4/wLbARqybSZ3Jb8IxHK5UGVbZaae0wtXAyQshVV+SeqVBik+Fbmw==}
     engines: {node: '>=8'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       fs-tree-diff: 2.0.1
       mkdirp: 0.5.6
       quick-temp: 0.1.8
@@ -18757,7 +19303,7 @@ packages:
   /workerpool@3.1.2:
     resolution: {integrity: sha512-WJFA0dGqIK7qj7xPTqciWBH5DlJQzoPjsANvc3Y4hNB0SScT+Emjvt0jPPkDBUjBNngX1q9hHgt1Gfwytu6pug==}
     dependencies:
-      '@babel/core': 7.22.5(supports-color@8.1.1)
+      '@babel/core': 7.22.5
       object-assign: 4.1.1
       rsvp: 4.8.5
     transitivePeerDependencies:
@@ -18947,6 +19493,7 @@ packages:
     resolution: {directory: ember-headless-table, type: directory}
     id: file:ember-headless-table
     name: ember-headless-table
+    version: 2.1.4
     peerDependencies:
       '@ember/test-helpers': '>= 2.6.0'
       '@ember/test-waiters': ^2.4.5 || >= 3.0.0
@@ -18960,24 +19507,25 @@ packages:
       ember-cached-decorator-polyfill:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.5
-      '@ember/string': 3.1.0
+      '@babel/runtime': 7.24.7
+      '@ember/string': 3.1.1
       '@ember/test-helpers': 2.9.3(@babel/core@7.21.4)(@glint/template@1.0.2)(ember-source@3.28.11)
       '@ember/test-waiters': 3.0.2
-      '@embroider/addon-shim': 1.8.4
+      '@embroider/addon-shim': 1.8.9
       '@embroider/macros': 1.10.0
       '@glimmer/component': 1.1.2(@babel/core@7.21.4)
       '@glint/template': 1.0.2
       ember-cached-decorator-polyfill: 1.0.1(@babel/core@7.21.4)(ember-source@3.28.11)
       ember-modifier: 3.2.7(@babel/core@7.21.4)
-      ember-resources: 5.6.4(@ember/test-waiters@3.0.2)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@3.28.11)
+      ember-modify-based-class-resource: 1.1.0(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(ember-resources@7.0.2)(ember-source@3.28.11)
+      ember-resources: 7.0.2(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@3.28.11)
       ember-source: 3.28.11(@babel/core@7.21.4)
       ember-tracked-storage-polyfill: 1.0.0
+      reactiveweb: 1.3.0(@babel/core@7.21.4)(@ember/test-waiters@3.0.2)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@3.28.11)
       tracked-built-ins: 3.1.1
     transitivePeerDependencies:
       - '@babel/core'
       - '@glimmer/tracking'
-      - ember-concurrency
       - supports-color
     dev: false
 
@@ -18985,6 +19533,7 @@ packages:
     resolution: {directory: ember-headless-table, type: directory}
     id: file:ember-headless-table
     name: ember-headless-table
+    version: 2.1.4
     peerDependencies:
       '@ember/test-helpers': '>= 2.6.0'
       '@ember/test-waiters': ^2.4.5 || >= 3.0.0
@@ -18998,23 +19547,24 @@ packages:
       ember-cached-decorator-polyfill:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.5
-      '@ember/string': 3.1.0
+      '@babel/runtime': 7.24.7
+      '@ember/string': 3.1.1
       '@ember/test-helpers': 2.9.4(@babel/core@7.22.5)(@glint/template@1.0.2)(ember-source@4.12.0)
       '@ember/test-waiters': 3.0.2
-      '@embroider/addon-shim': 1.8.4
+      '@embroider/addon-shim': 1.8.9
       '@embroider/macros': 1.10.0
       '@glimmer/component': 1.1.2(@babel/core@7.22.5)
       '@glint/template': 1.0.2
       ember-cached-decorator-polyfill: 1.0.1(@babel/core@7.22.5)(ember-source@4.12.0)
       ember-modifier: 3.2.7(@babel/core@7.22.5)
-      ember-resources: 5.6.4(@ember/test-waiters@3.0.2)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.12.0)
+      ember-modify-based-class-resource: 1.1.0(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(ember-resources@7.0.2)(ember-source@4.12.0)
+      ember-resources: 7.0.2(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.12.0)
       ember-source: 4.12.0(@babel/core@7.22.5)(@glimmer/component@1.1.2)(webpack@5.83.1)
       ember-tracked-storage-polyfill: 1.0.0
+      reactiveweb: 1.3.0(@babel/core@7.22.5)(@ember/test-waiters@3.0.2)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.0.2)(ember-source@4.12.0)
       tracked-built-ins: 3.1.1
     transitivePeerDependencies:
       - '@babel/core'
       - '@glimmer/tracking'
-      - ember-concurrency
       - supports-color
     dev: false


### PR DESCRIPTION
Via 
```bash
npx ember-resources-codemod
```

Here is the code for the codemod:
https://github.com/NullVoxPopuli/ember-resources/pull/1147

----------

There aren't many breaking changes from v5 to v7.

Here are the breaking changes in v6:
- https://github.com/NullVoxPopuli/ember-resources/releases/tag/ember-resources%406.0.0
  - Of note, the `map` utility (which this library uses) has changed its type signature for better inference)
  - most of the changes here do not affect ember-headless-table because most of the changes are from utilities that ember-headless-table doesn't import/use (more on this in v7)
  
Here are the breaking changes in v7:
- https://github.com/NullVoxPopuli/ember-resources/releases/tag/v7.0.0-ember-resources
  - All utilities moved to `reactiveweb`, documentation here: https://reactive.nullvoxpopuli.com/
  - This mostly doesn't affect ember-headless-table, because ember-headless-table is only using `map`
  - Additionally, the `Resource` class has moved to a separate package, https://github.com/NullVoxPopuli/ember-modify-based-class-resource/
    - This is to align with the ember ecosystem, and the desire to move away from `modify()` hooks -- as they are a sort of backdoor effect, which we don't want to encourage -- instead folks should rely on more data derivation patterns (ember-headless-table is, in general, a great example of data derivation)
    
-----------

Of note, because ember-resources has such broad support (3.28 - 6+), ember-resources declares a peer on `ember-source` so that it can correctly choose which features to use based on the consuming app's version.

As a result, `ember-resources` (in pnpm7 anyway), `ember-resources` must also become a peer, which is a _breaking change_. (However, I'm exploring if peers can be removed entirely here https://discord.com/channels/480462759797063690/568935504288940056/1281690947708784681 -- which would make this PR _not_ a breaking change (once I propagate the findings to the relevant libraries))


There is a fair bit of this code:
```ts
import { dependencySatisfies, importSync, macroCondition } from '@embroider/macros';

let getOwner: (context: unknown) => Owner | undefined;
let setOwner: (context: unknown, owner: Owner) => void;

if (macroCondition(dependencySatisfies('ember-source', '>=4.12.0'))) {
  getOwner = importSync('@ember/owner').getOwner;
  setOwner = importSync('@ember/owner') .setOwner;
} else {
  getOwner = importSync('@ember/application').getOwner;
  setOwner = importSync('@ember/application').setOwner;
}
```

The default ember-source for ember-headless-table is v4, but it looks like 3.28+ is also supported (the same range as ember-resources).

Though, while addressing this, I ran in to a number of peer problems. It may be best to address those in separate PRs, but they are included here in hopes that CI goes green, since I hadn't yet contributed to this repo since my time at CS.
![image](https://github.com/user-attachments/assets/309ad1ff-406f-4e79-aa8e-17692a67b0df)


I also ran in to a number of maintenance problems that will probably _not_ mean this PR will go green
- out of date dependencies:
  - `@embroider/*`
  - `ember-cli`
  - `ember-auto-import`
  - `pnpm`
 
These alone are not problematic _except_ when wanting to have fixed build problems.
In particular, I noticed with the current repo's dependencies, the dependency graph is incorrect, and packages are being resolved incorrectly -- for example, something is trying to resolve `reactiveweb/dist/index`, but that file doesn't exist, and nor should it -- because you only pay for what you import, and having a barrel file for a generic library would be bad for performance.

So, I guess this PR is more demonstration than anything, as other work must happen before this work can attempt to go green.

(If I used this library, I'd PR fixes for ya'll -- but I haven't had a need for a table in a while -- my timebox ran out on trying to get this repo working <3 )